### PR TITLE
NISP-1603: Fix GA pageview event duplication

### DIFF
--- a/app/uk/gov/hmrc/nisp/views/account.scala.html
+++ b/app/uk/gov/hmrc/nisp/views/account.scala.html
@@ -34,8 +34,23 @@
 <script src="@routes.Assets.at("javascript/account.js")" type="text/javascript"></script>
 }
 
+@analyticsAdditionalJs = {
+    ga('set', {
+        'dimension7':  '@spSummary.contextMessage.getOrElse("")',
+        'dimension8':  '@spSummary.forecastAmount.week.toInt',
+        @Html(abTest.map (p => s"'dimension9':  '${p.toString}',").getOrElse(""))
+        'dimension10': '@spSummary.numberOfQualifyingYears',
+        'dimension11': '@spSummary.numberOfGaps',
+        'dimension12': '@spSummary.numberOfGapsPayable',
+        'dimension13': '@spSummary.yearsToContributeUntilPensionAge',
+        'dimension14': '@spSummary.contractedOutFlag',
+        'dimension15': '@spSummary.statePensionAge',
+        'dimension16': '@spSummary.copeAmount.week'
+    });
+}
+
 @nispMain(serviceInfoContent=Some(includes.loginInfo(user)), userLoggedIn = true, browserTitle = Messages("nisp.main.title"),
-            pageScripts=Some(pageScripts), articleClasses = Some("mainpage")) {
+            pageScripts=Some(pageScripts), articleClasses = Some("mainpage"), analyticsAdditionalJs = Some(analyticsAdditionalJs)) {
 
     <div class="grid services">
                <h1 class="heading-large title-spa">@Messages("nisp.main.h1.title")</h1>
@@ -174,20 +189,4 @@
             </div>
         </div>
     </div>
-    <script type="text/javascript">
-           $(document).ready(function(){
-               ga('send', 'pageview', {
-                  'dimension7':  '@spSummary.contextMessage.getOrElse("")',
-                  'dimension8':  '@spSummary.forecastAmount.week.toInt',
-                  @Html(abTest.map (p => s"'dimension9':  '${p.toString}',").getOrElse(""))
-                  'dimension10': '@spSummary.numberOfQualifyingYears',
-                  'dimension11': '@spSummary.numberOfGaps',
-                  'dimension12': '@spSummary.numberOfGapsPayable',
-                  'dimension13': '@spSummary.yearsToContributeUntilPensionAge',
-                  'dimension14': '@spSummary.contractedOutFlag',
-                  'dimension15': '@spSummary.statePensionAge',
-                  'dimension16': '@spSummary.copeAmount.week'
-               });
-           });
-    </script>
 }

--- a/app/uk/gov/hmrc/nisp/views/excluded.scala.html
+++ b/app/uk/gov/hmrc/nisp/views/excluded.scala.html
@@ -19,7 +19,15 @@
 
 @(nino: String,spExclusions: SPExclusionsModel, user: uk.gov.hmrc.nisp.controllers.auth.NispUser)(implicit request: Request[_])
 
-@nispMain(browserTitle=Messages("nisp.main.title"), pageTitle = Some(Messages("nisp.excluded.title")), serviceInfoContent=Some(includes.loginInfo(user)), userLoggedIn = true) {
+
+@analyticsAdditionalJs = {
+    ga('set', {
+        'dimension20': '@spExclusions.spExclusions.map(_.toString).mkString(" ") '
+    });
+}
+
+@nispMain(browserTitle=Messages("nisp.main.title"), pageTitle = Some(Messages("nisp.excluded.title")), serviceInfoContent=Some(includes.loginInfo(user)),
+            userLoggedIn = true, analyticsAdditionalJs = Some(analyticsAdditionalJs)) {
 
 
     @if(spExclusions.spExclusions.contains(SPExclusion.Abroad)) {
@@ -40,12 +48,4 @@
     @if(spExclusions.spExclusions.contains(SPExclusion.AmountDissonance)) {
         @exclusions.amountDissonance()
     }
-
-<script type="text/javascript">
-    $(document).ready(function(){
-        ga('send', 'pageview', {
-            'dimension20': '@spExclusions.spExclusions.map(_.toString).mkString(" ") '
-        });
-    });
-</script>
 }

--- a/app/uk/gov/hmrc/nisp/views/main.scala.html
+++ b/app/uk/gov/hmrc/nisp/views/main.scala.html
@@ -31,7 +31,8 @@
     showTitleHeaderNav: Boolean = true,
     showBetaBanner: Boolean = true,
     pageScripts: Option[Html] = None,
-    articleClasses: Option[String] = None)(mainContent: Html)(implicit request : Request[_])
+    articleClasses: Option[String] = None,
+    analyticsAdditionalJs: Option[Html] = None)(mainContent: Html)(implicit request : Request[_])
 
 
 @linkElement = {
@@ -121,7 +122,8 @@
         ssoUrl = applicationConfig.ssoUrl,
         scriptElem = None,
         gaCalls = gaCalls,
-        analyticsAnonymizeIp = true
+        analyticsAnonymizeIp = true,
+        analyticsAdditionalJs = analyticsAdditionalJs
     )
     @pageScripts
 }

--- a/app/uk/gov/hmrc/nisp/views/nispMain.scala.html
+++ b/app/uk/gov/hmrc/nisp/views/nispMain.scala.html
@@ -26,7 +26,8 @@
     showBetaBanner: Boolean = true,
     pageScripts: Option[Html] = None,
     contentHeaderExtra: Option[Html] = None,
-    articleClasses: Option[String] = None)(mainContent: Html)(implicit request:Request[_])
+    articleClasses: Option[String] = None,
+    analyticsAdditionalJs: Option[Html] = None)(mainContent: Html)(implicit request:Request[_])
 
 @contentHeader = {
     @loginDetailsHeader
@@ -43,7 +44,8 @@
     showTitleHeaderNav = showTitleHeaderNav,
     showBetaBanner = showBetaBanner,
     pageScripts = pageScripts,
-    articleClasses = articleClasses) {
+    articleClasses = articleClasses,
+    analyticsAdditionalJs = analyticsAdditionalJs) {
         @if(pageTitle.isDefined) {
         <h1 class="heading-large @h1Classes"> @pageTitle </h1>
         }

--- a/project/FrontendBuild.scala
+++ b/project/FrontendBuild.scala
@@ -53,7 +53,7 @@ private object AppDependencies {
     "uk.gov.hmrc" %% "play-json-logger" % "2.1.1",
     "uk.gov.hmrc" %% "play-health" % "1.1.0",
     "uk.gov.hmrc" %% "govuk-template" % "4.0.0",
-    "uk.gov.hmrc" %% "play-ui" % "4.2.0",
+    "uk.gov.hmrc" %% "play-ui" % "4.4.0",
     "uk.gov.hmrc" %% "url-builder" % "1.0.0",
     "com.kenshoo" %% "metrics-play" % "2.3.0_0.1.8",
     "uk.gov.hmrc" %% "http-caching-client" % httpCachingClientVersion,


### PR DESCRIPTION
* The dimension code has been changed to ```set``` rather than send a ```send pageview```
* The analytics code is now sent to play-ui so we no longer have to handle the submission see https://github.com/hmrc/play-ui/blob/master/src/main/twirl/uk/gov/hmrc/play/views/layouts/footer.scala.html