### PR TITLE
NISP-1621: Add link to contact FPC exclusion messages

### DIFF
--- a/app/uk/gov/hmrc/nisp/views/exclusions/isleOfMan.scala.html
+++ b/app/uk/gov/hmrc/nisp/views/exclusions/isleOfMan.scala.html
@@ -18,8 +18,6 @@
 
 @()
 
-
-
 @****************************@
 @*                          *@
 @*  Exclusion template for  *@
@@ -27,9 +25,7 @@
 @*                          *@
 @****************************@
 
-
-
-
 @viewExclusions() {
         <p> @Html(Messages("nisp.excluded.isleOfMan")) </p>
+        <p> @Html(Messages("nisp.excluded.contactFuturePensionCentre")) </p>
 }

--- a/app/uk/gov/hmrc/nisp/views/exclusions/overseas.scala.html
+++ b/app/uk/gov/hmrc/nisp/views/exclusions/overseas.scala.html
@@ -18,8 +18,6 @@
 
 @()
 
-
-
 @****************************@
 @*                          *@
 @*  Exclusion template for  *@
@@ -27,12 +25,10 @@
 @*                          *@
 @****************************@
 
-
-
-
 @viewExclusions() {
         <p> @Html(Messages("nisp.excluded.overseas.line1")) </p>
         <p> @Html(Messages("nisp.excluded.overseas.line2")) </p>
         <p> @Html(Messages("nisp.excluded.overseas.line3")) </p>
         <p> @Html(Messages("nisp.excluded.overseas.line4")) </p>
+        <p> @Html(Messages("nisp.excluded.contactFuturePensionCentre")) </p>
 }

--- a/conf/messages
+++ b/conf/messages
@@ -109,20 +109,25 @@ nisp.main.context.improve.para1.priya.singular = You have {0} year on your Natio
 
 nisp.excluded.title = You are unable to use this service
 
-nisp.excluded.overseas.line1 = If you''ve worked in the UK and abroad, you must send an international claim form to the International Pension Centre (IPC).
-nisp.excluded.overseas.line2 = If you''ve only worked, lived or are working abroad, you must claim your State Pension through the relevant authority of the country you''re in if you currently live and have worked in:
-nisp.excluded.overseas.line3 = Austria, Belgium, Bulgaria, Croatia, Cyprus, Czech Republic, Denmark, Estonia, Finland, France, Germany, Gibraltar, Greece, Hungary, Iceland, Ireland, Italy, Latvia, Liechtenstein, Lithuania, Luxembourg, Malta, Netherlands, Norway, Poland, Portugal, Romania, Slovakia, Slovenia, Spain, Sweden or Switzerland.
-nisp.excluded.overseas.line4 = <a href="https://www.gov.uk/state-pension-if-you-retire-abroad/how-to-claim" rel="external" target="_blank" data-journey-click="checkmystatepension:external:howtoclaimabroad">Contact the IPC (opens in new tab)</a> if you''ve worked or lived in a country not listed above.
+nisp.excluded.amountdissonance = We are having problems calculating your State Pension forecast. We are currently investigating this matter. You do not need to take any action.
 
-nisp.excluded.mwrre.line1 = You chose to pay a <a href="https://www.gov.uk/reduced-national-insurance-married-women" rel="external" target="_blank" data-journey-click="checkmystatepension:external:mwrre">reduced rate of National Insurance as a married woman (opens in new tab)</a> and your State Pension has been reduced. You may be able to claim a pension benefit based on your partner''s contributions.
-nisp.excluded.mwrre.line2 = To get a married women''s reduced rate elective pension statement, you will need to <a href="https://www.gov.uk/future-pension-centre" rel="external" target="_blank" data-journey-click="checkmystatepension:external:futurepensioncentre">contact the Future Pension Centre (opens in new tab)</a>.
-
-nisp.excluded.spaBefore5April2016 = You will have reached State Pension age before the new scheme starts. You must refer to the <a href="https://www.gov.uk/state-pension/overview" rel="external" data-journey-click="checkmystatepension:external:statepensionoverview" target="_blank">information about the old scheme (opens in new tab)</a>.
+nisp.excluded.contactFuturePensionCentre = To get a statement of how much pension you''ve earned so far, <a href="https://www.gov.uk/future-pension-centre" rel="external" target="_blank" data-journey-click="checkmystatepension:external:futurepensioncentre">contact the Future Pension Centre (opens in new tab)</a>.
 
 nisp.excluded.dead = Please contact HMRC National Insurance helpline on 0300 200 3500.
 
 nisp.excluded.isleOfMan = The Isle of Man Government is currently undertaking a review of its Retirement Pension scheme. It will not be adopting the State Pension reforms from 6 April 2016. For more information about the Retirement Pension scheme, visit <a href="https://www.gov.im/categories/benefits-and-financial-support/social-security-benefits/retirement-and-pensions/retirement-pension/" rel="external" target="_blank" data-journey-click="checkmystatepension:external:iom">GOV.IM – Retirement Pension (opens in new tab)</a>.
-nisp.excluded.amountdissonance = We are having problems calculating your State Pension forecast. We are currently investigating this matter. You do not need to take any action.
+
+nisp.excluded.mwrre.line1 = You chose to pay a <a href="https://www.gov.uk/reduced-national-insurance-married-women" rel="external" target="_blank" data-journey-click="checkmystatepension:external:mwrre">reduced rate of National Insurance as a married woman (opens in new tab)</a> and your State Pension has been reduced. You may be able to claim a pension benefit based on your partner''s contributions.
+nisp.excluded.mwrre.line2 = To get a married women''s reduced rate elective pension statement, you will need to <a href="https://www.gov.uk/future-pension-centre" rel="external" target="_blank" data-journey-click="checkmystatepension:external:futurepensioncentre">contact the Future Pension Centre (opens in new tab)</a>.
+
+nisp.excluded.overseas.line1 = If you''ve worked in the UK and abroad, you must send an international claim form to the International Pension Centre (IPC).
+nisp.excluded.overseas.line2 = If you''ve only worked or lived abroad, you must claim your State Pension through the relevant authority of that country:
+nisp.excluded.overseas.line3 = Austria, Belgium, Bulgaria, Croatia, Cyprus, Czech Republic, Denmark, Estonia, Finland, France, Germany, Gibraltar, Greece, Hungary, Iceland, Ireland, Italy, Latvia, Liechtenstein, Lithuania, Luxembourg, Malta, Netherlands, Norway, Poland, Portugal, Romania, Slovakia, Slovenia, Spain, Sweden or Switzerland.
+nisp.excluded.overseas.line4 = <a href="https://www.gov.uk/state-pension-if-you-retire-abroad/how-to-claim" rel="external" target="_blank" data-journey-click="checkmystatepension:external:howtoclaimabroad">Contact the IPC (opens in new tab)</a> if you''ve worked or lived in a country not listed above.
+
+nisp.excluded.spaBefore5April2016 = You will have reached State Pension age before the new scheme starts. You must refer to the <a href="https://www.gov.uk/state-pension/overview" rel="external" data-journey-click="checkmystatepension:external:statepensionoverview" target="_blank">information about the old scheme (opens in new tab)</a>.
+
+
 
 #**************************
 #  NPS Unavailable Page Messages


### PR DESCRIPTION
@swatcats143 and @InduTest - I have added a link to contact the FPC on the IOM and Overseas exclusion messages. Also a minor text change on the second paragraph of the Overseas exclusion.