### PR TITLE
NISP-1620 Fixed issue with Iphone 6 landscape view of NI record page

### DIFF
--- a/app/uk/gov/hmrc/nisp/assets/sass/_nirecord.scss
+++ b/app/uk/gov/hmrc/nisp/assets/sass/_nirecord.scss
@@ -5,22 +5,22 @@
   float: left;
   text-align: right;
   width: 40%;
+  @media only screen and (max-width: 640px) {
+    width: 30%;
+  }
 }
 
 .ni-years {
   float: left;
-  width: 20%;
+  width: 25%;
   @media only screen and (max-width: 640px) {
-    width: 25%;
+    width: 35%;
   }
 }
 
 .ni-notfull {
   float: left;
-  width: 40%;
-  @media only screen and (max-width: 640px) {
-    width: 35%;
-  }
+  width: 35%;  
 }
 
 .contributions-wrapper {
@@ -28,7 +28,7 @@
   display: block;
   font-size: 16px;
   margin-bottom: 5px;
-  padding: 0 0 0 20%;
+  padding: 0 0 0 25%;
   
   @media only screen and (max-width: 640px) {
     padding: 0;


### PR DESCRIPTION
Adjusted width percentages, so it works even in Iphone 6 landscape! Also tested with desktop browsers and other mobile devices.