### PR TITLE
NISP-1732: Add Exclusions and isAbroad to NI

### DIFF
--- a/app/uk/gov/hmrc/nisp/connectors/NispConnector.scala
+++ b/app/uk/gov/hmrc/nisp/connectors/NispConnector.scala
@@ -53,7 +53,7 @@ trait NispConnector {
 
   def connectToGetNIResponse(nino: String)(implicit hc: HeaderCarrier): Future[NIResponse] = {
     val urlToRead = s"$serviceUrl/nisp/$nino/nirecord"
-    retrieveFromCache[NIResponse](APIType.NI, urlToRead) map (_.getOrElse(NIResponse(None, None)))
+    retrieveFromCache[NIResponse](APIType.NI, urlToRead) map (_.getOrElse(NIResponse(None, None, None)))
   }
 
   private def retrieveFromCache[A](api: APIType, url: String)(implicit hc: HeaderCarrier, formats: Format[A]): Future[Option[A]] = {

--- a/app/uk/gov/hmrc/nisp/controllers/AccountController.scala
+++ b/app/uk/gov/hmrc/nisp/controllers/AccountController.scala
@@ -66,15 +66,17 @@ trait AccountController extends NispFrontendController with AuthorisedForNisp wi
         case SPResponseModel(Some(spSummary: SPSummaryModel), None) =>
           metricsService.abTest(getABTest(nino, spSummary.contractedOutFlag))
 
-          customAuditConnector.sendEvent(AccountAccessEvent(nino, spSummary.contextMessage, spSummary.statePensionAge.date, spSummary.statePensionAmount.week,
-            spSummary.forecastAmount.week, spSummary.dateOfBirth, user.name, spSummary.contractedOutFlag, spSummary.forecastOnlyFlag,
+          customAuditConnector.sendEvent(AccountAccessEvent(nino, spSummary.contextMessage,
+            spSummary.statePensionAge.date, spSummary.statePensionAmount.week, spSummary.forecastAmount.week,
+            spSummary.dateOfBirth, user.name, spSummary.contractedOutFlag, spSummary.forecastOnlyFlag,
             getABTest(nino, spSummary.contractedOutFlag), spSummary.copeAmount.week, authenticationProvider))
 
           if (spSummary.numberOfQualifyingYears + spSummary.yearsToContributeUntilPensionAge < Constants.minimumQualifyingYearsNSP) {
             val canGetPension = spSummary.numberOfQualifyingYears +
               spSummary.yearsToContributeUntilPensionAge + spSummary.numberOfGapsPayable >= Constants.minimumQualifyingYearsNSP
             val yearsMissing = Constants.minimumQualifyingYearsNSP - spSummary.numberOfQualifyingYears
-            Ok(account_mqp(nino, spSummary, canGetPension, yearsMissing, authenticationProvider, isPertax)).withSession(storeUserInfoInSession(user, contractedOut = false))
+            Ok(account_mqp(nino, spSummary, canGetPension, yearsMissing, authenticationProvider, isPertax))
+              .withSession(storeUserInfoInSession(user, contractedOut = false))
           } else if (spSummary.forecastOnlyFlag) {
             Ok(account_forecastonly(nino, spSummary, authenticationProvider,isPertax)).withSession(storeUserInfoInSession(user, contractedOut = false))
           } else {
@@ -83,11 +85,11 @@ trait AccountController extends NispFrontendController with AuthorisedForNisp wi
               .withSession(storeUserInfoInSession(user, spSummary.contractedOutFlag))
           }
 
-        case SPResponseModel(_, Some(spExclusions: SPExclusionsModel)) =>
+        case SPResponseModel(_, Some(spExclusions: ExclusionsModel)) =>
           customAuditConnector.sendEvent(AccountExclusionEvent(
             nino,
             user.name,
-            spExclusions.spExclusions
+            spExclusions.exclusions
           ))
           Redirect(routes.ExclusionController.show()).withSession(storeUserInfoInSession(user, contractedOut = false))
         case _ => throw new RuntimeException("SP Response Model is empty")

--- a/app/uk/gov/hmrc/nisp/controllers/ExclusionController.scala
+++ b/app/uk/gov/hmrc/nisp/controllers/ExclusionController.scala
@@ -22,7 +22,7 @@ import uk.gov.hmrc.nisp.config.ApplicationConfig
 import uk.gov.hmrc.nisp.connectors.NispConnector
 import uk.gov.hmrc.nisp.controllers.auth.AuthorisedForNisp
 import uk.gov.hmrc.nisp.controllers.connectors.AuthenticationConnectors
-import uk.gov.hmrc.nisp.models.{SPExclusionsModel, SPResponseModel}
+import uk.gov.hmrc.nisp.models.{ExclusionsModel, SPResponseModel}
 import uk.gov.hmrc.nisp.services.{NpsAvailabilityChecker, CitizenDetailsService}
 import uk.gov.hmrc.nisp.views.html.excluded
 import uk.gov.hmrc.nisp.controllers.partial.PartialRetriever
@@ -40,7 +40,7 @@ trait ExclusionController extends NispFrontendController with AuthorisedForNisp 
   def show: Action[AnyContent] = AuthorisedByAny.async { implicit user => implicit request =>
     val nino = user.nino.getOrElse("")
     nispConnector.connectToGetSPResponse(nino).map{
-      case SPResponseModel(_, Some(spExclusions: SPExclusionsModel)) => Ok(excluded(nino, spExclusions))
+      case SPResponseModel(_, Some(spExclusions: ExclusionsModel)) => Ok(excluded(nino, spExclusions))
       case _ =>
         Logger.warn("User accessed /exclusion as non-excluded user")
         Redirect(routes.AccountController.show())

--- a/app/uk/gov/hmrc/nisp/controllers/NIRecordController.scala
+++ b/app/uk/gov/hmrc/nisp/controllers/NIRecordController.scala
@@ -59,7 +59,7 @@ trait NIRecordController extends NispFrontendController with AuthorisedForNisp w
     implicit user => implicit request =>
       val nino = user.nino.getOrElse("")
       nispConnector.connectToGetNIResponse(nino).map {
-        case NIResponse(Some(niRecord: NIRecord), Some(niSummary: NISummary)) =>
+        case NIResponse(Some(niRecord: NIRecord), Some(niSummary: NISummary), None) =>
           if (niGaps && niSummary.noOfNonQualifyingYears < 1) {
             Redirect(routes.NIRecordController.showFull())
           } else {

--- a/app/uk/gov/hmrc/nisp/events/AccountExclusionEvent.scala
+++ b/app/uk/gov/hmrc/nisp/events/AccountExclusionEvent.scala
@@ -16,14 +16,14 @@
 
 package uk.gov.hmrc.nisp.events
 
-import uk.gov.hmrc.nisp.models.enums.SPExclusion.SPExclusion
+import uk.gov.hmrc.nisp.models.enums.Exclusion.Exclusion
 import uk.gov.hmrc.play.http.HeaderCarrier
 
 object AccountExclusionEvent {
-  def apply(nino: String, name: Option[String], spExclusions: List[SPExclusion])(implicit hc: HeaderCarrier): AccountExclusionEvent =
+  def apply(nino: String, name: Option[String], spExclusions: List[Exclusion])(implicit hc: HeaderCarrier): AccountExclusionEvent =
     new AccountExclusionEvent(nino,name.getOrElse("N/A"), spExclusions)
 }
-class AccountExclusionEvent(nino: String, name: String, spExclusions: List[SPExclusion])(implicit hc: HeaderCarrier)
+class AccountExclusionEvent(nino: String, name: String, spExclusions: List[Exclusion])(implicit hc: HeaderCarrier)
   extends NispBusinessEvent("Exclusion",
   Map(
     "nino" -> nino,

--- a/app/uk/gov/hmrc/nisp/models/ExclusionsModel.scala
+++ b/app/uk/gov/hmrc/nisp/models/ExclusionsModel.scala
@@ -16,12 +16,12 @@
 
 package uk.gov.hmrc.nisp.models
 
-import uk.gov.hmrc.nisp.models.enums.SPExclusion
-import SPExclusion.SPExclusion
+import uk.gov.hmrc.nisp.models.enums.Exclusion
+import Exclusion.Exclusion
 import play.api.libs.json.Json
 
-case class SPExclusionsModel(spExclusions: List[SPExclusion])
+case class ExclusionsModel(exclusions: List[Exclusion])
 
-object SPExclusionsModel {
-  implicit val formats = Json.format[SPExclusionsModel]
+object ExclusionsModel {
+  implicit val formats = Json.format[ExclusionsModel]
 }

--- a/app/uk/gov/hmrc/nisp/models/NIResponse.scala
+++ b/app/uk/gov/hmrc/nisp/models/NIResponse.scala
@@ -18,7 +18,7 @@ package uk.gov.hmrc.nisp.models
 
 import play.api.libs.json.Json
 
-case class NIResponse(niRecord: Option[NIRecord], niSummary: Option[NISummary])
+case class NIResponse(niRecord: Option[NIRecord], niSummary: Option[NISummary], niExclusions: Option[ExclusionsModel])
 
 object NIResponse {
   implicit val formats = Json.format[NIResponse]

--- a/app/uk/gov/hmrc/nisp/models/NISummary.scala
+++ b/app/uk/gov/hmrc/nisp/models/NISummary.scala
@@ -19,8 +19,9 @@ package uk.gov.hmrc.nisp.models
 import play.api.libs.json.Json
 
 case class NISummary(noOfQualifyingYears: Int, noOfNonQualifyingYears: Int, yearsToContributeUntilPensionAge: Int,
-                      spaYear: Int, earningsIncludedUpTo: NpsDate, unavailableYear: Int, pre75QualifyingYears : Option[Int],
-                      numberOfPayableGaps: Int, numberOfNonPayableGaps: Int, canImproveWithGaps: Boolean)
+                     spaYear: Int, earningsIncludedUpTo: NpsDate, unavailableYear: Int,
+                     pre75QualifyingYears: Option[Int], numberOfPayableGaps: Int, numberOfNonPayableGaps: Int,
+                     canImproveWithGaps: Boolean, isAbroad: Boolean)
 
 object NISummary {
   implicit val formats = Json.format[NISummary]

--- a/app/uk/gov/hmrc/nisp/models/SPResponseModel.scala
+++ b/app/uk/gov/hmrc/nisp/models/SPResponseModel.scala
@@ -18,7 +18,7 @@ package uk.gov.hmrc.nisp.models
 
 import play.api.libs.json.Json
 
-case class SPResponseModel(spSummary: Option[SPSummaryModel], spExclusions: Option[SPExclusionsModel] = None)
+case class SPResponseModel(spSummary: Option[SPSummaryModel], spExclusions: Option[ExclusionsModel] = None)
 
 object SPResponseModel {
   implicit val formats = Json.format[SPResponseModel]

--- a/app/uk/gov/hmrc/nisp/models/enums/Exclusion.scala
+++ b/app/uk/gov/hmrc/nisp/models/enums/Exclusion.scala
@@ -19,8 +19,8 @@ package uk.gov.hmrc.nisp.models.enums
 import play.api.i18n.Messages
 import play.api.libs.json._
 
-object SPExclusion extends Enumeration {
-  type SPExclusion = Value
+object Exclusion extends Enumeration {
+  type Exclusion = Value
   val Abroad = Value
   val MWRRE = Value
   val CustomerTooOld = Value
@@ -30,8 +30,8 @@ object SPExclusion extends Enumeration {
   val AmountDissonance = Value
   val PostStatePensionAge = Value
 
-  implicit val formats = new Format[SPExclusion] {
-    def reads(json: JsValue): JsResult[SPExclusion] = JsSuccess(SPExclusion.withName(json.as[String]) )
-    def writes(spExclusion: SPExclusion): JsValue = JsString(spExclusion.toString)
+  implicit val formats = new Format[Exclusion] {
+    def reads(json: JsValue): JsResult[Exclusion] = JsSuccess(Exclusion.withName(json.as[String]) )
+    def writes(spExclusion: Exclusion): JsValue = JsString(spExclusion.toString)
   }
 }

--- a/app/uk/gov/hmrc/nisp/services/MetricsService.scala
+++ b/app/uk/gov/hmrc/nisp/services/MetricsService.scala
@@ -19,9 +19,9 @@ package uk.gov.hmrc.nisp.services
 import com.codahale.metrics.{Timer, Counter, Meter}
 import com.kenshoo.play.metrics.MetricsRegistry
 import uk.gov.hmrc.nisp.models.enums.ABTest.ABTest
-import uk.gov.hmrc.nisp.models.enums.{APIType, ABTest, SPExclusion, SPContextMessage}
+import uk.gov.hmrc.nisp.models.enums.{APIType, ABTest, Exclusion, SPContextMessage}
 import uk.gov.hmrc.nisp.models.enums.SPContextMessage.SPContextMessage
-import uk.gov.hmrc.nisp.models.enums.SPExclusion.SPExclusion
+import uk.gov.hmrc.nisp.models.enums.Exclusion.Exclusion
 
 trait MetricsService {
   def abTest(abTest: Option[ABTest])

--- a/app/uk/gov/hmrc/nisp/views/excluded.scala.html
+++ b/app/uk/gov/hmrc/nisp/views/excluded.scala.html
@@ -14,45 +14,42 @@
 * limitations under the License.
 *@
 
-@import uk.gov.hmrc.nisp.models.enums.SPExclusion
-@import uk.gov.hmrc.nisp.models.SPExclusionsModel
+@import uk.gov.hmrc.nisp.models.enums.Exclusion
+@import uk.gov.hmrc.nisp.models.ExclusionsModel
 @import uk.gov.hmrc.nisp.controllers.auth.NispUser
 @import uk.gov.hmrc.play.partials.CachedStaticHtmlPartialRetriever
 
-@(nino: String,spExclusions: SPExclusionsModel)(implicit request: Request[_], user: NispUser,
+@(nino: String, spExclusions: ExclusionsModel)(implicit request: Request[_], user: NispUser,
   partialRetriever: CachedStaticHtmlPartialRetriever)
-
 
 @analyticsAdditionalJs = {
     ga('set', {
-        'dimension20': '@spExclusions.spExclusions.map(_.toString).mkString(" ") '
+        'dimension20': '@spExclusions.exclusions.map(_.toString).mkString(" ") '
     });
 }
 
 @defining(Some(user)) { implicit userOption =>
-@nispMain(browserTitle=Messages("nisp.main.title"), pageTitle = Some(Messages("nisp.excluded.title")), userLoggedIn = true, analyticsAdditionalJs = Some(analyticsAdditionalJs)) {
-
-
-    @if(spExclusions.spExclusions.contains(SPExclusion.Abroad)) {
-        @exclusions.overseas()
+    @nispMain(browserTitle=Messages("nisp.main.title"), pageTitle = Some(Messages("nisp.excluded.title")), userLoggedIn = true, analyticsAdditionalJs = Some(analyticsAdditionalJs)) {
+        @if(spExclusions.exclusions.contains(Exclusion.Abroad)) {
+            @exclusions.overseas()
+        }
+        @if(spExclusions.exclusions.contains(Exclusion.MWRRE)) {
+            @exclusions.mwrre()
+        }
+        @if(spExclusions.exclusions.contains(Exclusion.CustomerTooOld)) {
+            @exclusions.spaBefore5April2016()
+        }
+        @if(spExclusions.exclusions.contains(Exclusion.Dead)) {
+            @exclusions.dead()
+        }
+        @if(spExclusions.exclusions.contains(Exclusion.IOM)) {
+            @exclusions.isleOfMan()
+        }
+        @if(spExclusions.exclusions.contains(Exclusion.AmountDissonance)) {
+            @exclusions.amountDissonance()
+        }
+        @if(spExclusions.exclusions.contains(Exclusion.PostStatePensionAge)) {
+            @exclusions.postStatePensionAge()
+        }
     }
-    @if(spExclusions.spExclusions.contains(SPExclusion.MWRRE)) {
-        @exclusions.mwrre()
-    }
-    @if(spExclusions.spExclusions.contains(SPExclusion.CustomerTooOld)) {
-        @exclusions.spaBefore5April2016()
-    }
-    @if(spExclusions.spExclusions.contains(SPExclusion.Dead)) {
-        @exclusions.dead()
-    }
-    @if(spExclusions.spExclusions.contains(SPExclusion.IOM)) {
-        @exclusions.isleOfMan()
-    }
-    @if(spExclusions.spExclusions.contains(SPExclusion.AmountDissonance)) {
-        @exclusions.amountDissonance()
-    }
-    @if(spExclusions.spExclusions.contains(SPExclusion.PostStatePensionAge)) {
-        @exclusions.postStatePensionAge()
-    }
-}
 }

--- a/test/resources/contractedout/nirecord.json
+++ b/test/resources/contractedout/nirecord.json
@@ -270,7 +270,8 @@
     "unavailableYear": 2014,
     "numberOfPayableGaps": 8,
     "numberOfNonPayableGaps": 16,
-    "canImproveWithGaps": true
+    "canImproveWithGaps": true,
+    "isAbroad": false
   }
 }
 

--- a/test/resources/excluded/nirecord.json
+++ b/test/resources/excluded/nirecord.json
@@ -168,7 +168,8 @@
     "spaYear": 2021,
     "earningsIncludedUpTo": "05\/04\/2014",
     "unavailableYear": 2015,
-    "pre75QualifyingYears": 1
+    "pre75QualifyingYears": 1,
+    "isAbroad": false
   }
 }
 

--- a/test/resources/excluded/summary.json
+++ b/test/resources/excluded/summary.json
@@ -1,1 +1,1 @@
-{"spExclusions":{"spExclusions":["ContractedOut","CustomerTooOld"]}}
+{"spExclusions":{"exclusions":["ContractedOut","CustomerTooOld"]}}

--- a/test/resources/forecastonly/nirecord.json
+++ b/test/resources/forecastonly/nirecord.json
@@ -270,7 +270,8 @@
     "unavailableYear": 2014,
     "numberOfPayableGaps": 8,
     "numberOfNonPayableGaps": 16,
-    "canImproveWithGaps": true
+    "canImproveWithGaps": true,
+    "isAbroad": false
   }
 }
 

--- a/test/resources/fulluser/nirecord.json
+++ b/test/resources/fulluser/nirecord.json
@@ -254,7 +254,8 @@
     "unavailableYear": 2014,
     "numberOfPayableGaps": 0,
     "numberOfNonPayableGaps": 0,
-    "canImproveWithGaps": true
+    "canImproveWithGaps": true,
+    "isAbroad": false
   }
 }
 

--- a/test/resources/mqp/nirecord.json
+++ b/test/resources/mqp/nirecord.json
@@ -318,7 +318,8 @@
     "unavailableYear": 2014,
     "numberOfPayableGaps": 7,
     "numberOfNonPayableGaps": 19,
-    "canImproveWithGaps": true
+    "canImproveWithGaps": true,
+    "isAbroad": false
   }
 }
 

--- a/test/resources/regular/nirecord.json
+++ b/test/resources/regular/nirecord.json
@@ -406,7 +406,8 @@
     "unavailableYear": 2014,
     "numberOfPayableGaps": 4,
     "numberOfNonPayableGaps": 6,
-    "canImproveWithGaps": false
+    "canImproveWithGaps": false,
+    "isAbroad": false
   }
 }
 

--- a/test/uk/gov/hmrc/nisp/connectors/NispConnectorSpec.scala
+++ b/test/uk/gov/hmrc/nisp/connectors/NispConnectorSpec.scala
@@ -65,7 +65,7 @@ class NispConnectorSpec extends UnitSpec with MockitoSugar with  BeforeAndAfter 
     NIRecordTaxYear(2003,true,2484.49,0,0,0,None,None,None,false, false), NIRecordTaxYear(2004,true,2573.95,0,0,0,None,None,None,false, false), NIRecordTaxYear(2005,true,2495.74,0,0,0,None,None,None,false, false), NIRecordTaxYear(2006,false,0,0,0,0,None,None,None,false, false),
     NIRecordTaxYear(2007,true,3312,0,0,0,None,None,None,false, false), NIRecordTaxYear(2008,true,2699.4,0,0,0,None,None,None,false, false), NIRecordTaxYear(2009,true,4259.6,0,0,0,None,None,None,false, false), NIRecordTaxYear(2010,false,0,0,0,0,Some(626.6),Some(NpsDate(new LocalDate(2019,4,5))),Some(NpsDate(new LocalDate(2023,4,5))),true, false),
     NIRecordTaxYear(2011,false,0,0,0,0,Some(655.2),Some(NpsDate(new LocalDate(2019,4,5))),Some(NpsDate(new LocalDate(2023,4,5))),true, false), NIRecordTaxYear(2012,false,0,0,0,0,Some(689.0),Some(NpsDate(new LocalDate(2019,4,5))),Some(NpsDate(new LocalDate(2023,4,5))),true, false), NIRecordTaxYear(2013,false,0,0,0,0,Some(704.6),Some(NpsDate(new LocalDate(2019,4,5))),Some(NpsDate(new LocalDate(2023,4,5))),true, false)
-  ))), Some(NISummary(28,10,13,2027,NpsDate(new LocalDate(2014,4,5)),2014,None,4,6,false)))
+  ))), Some(NISummary(28,10,13,2027,NpsDate(new LocalDate(2014,4,5)),2014,None,4,6,false, false)), None)
 
   "SPResponse" should {
     "return SPResponse instance with a SPSummary for valid JSON" in {

--- a/test/uk/gov/hmrc/nisp/helpers/MockMetricsService.scala
+++ b/test/uk/gov/hmrc/nisp/helpers/MockMetricsService.scala
@@ -18,7 +18,7 @@ package uk.gov.hmrc.nisp.helpers
 
 import uk.gov.hmrc.nisp.models.enums.ABTest.ABTest
 import uk.gov.hmrc.nisp.models.enums.SPContextMessage.SPContextMessage
-import uk.gov.hmrc.nisp.models.enums.SPExclusion.SPExclusion
+import uk.gov.hmrc.nisp.models.enums.Exclusion.Exclusion
 import uk.gov.hmrc.nisp.services.MetricsService
 
 object MockMetricsService extends MetricsService {

--- a/test/uk/gov/hmrc/nisp/models/enums/SPExclusionSpec.scala
+++ b/test/uk/gov/hmrc/nisp/models/enums/SPExclusionSpec.scala
@@ -16,7 +16,7 @@
 
 package uk.gov.hmrc.nisp.models.enums
 
-import SPExclusion.SPExclusion
+import Exclusion.Exclusion
 import play.api.libs.json.{JsString, Json}
 import uk.gov.hmrc.play.test.UnitSpec
 
@@ -28,11 +28,11 @@ class SPExclusionSpec extends UnitSpec {
   "SP Exclusion" when {
     "serialised into JSON" should {
       "output Abroad when Abroad is formatted" in {
-        Json.toJson(SPExclusion.Abroad) shouldBe JsString("Abroad")
+        Json.toJson(Exclusion.Abroad) shouldBe JsString("Abroad")
       }
 
       "parse Abroad when Abroad is read" in {
-        Json.fromJson[SPExclusion](JsString("Abroad")).get shouldBe SPExclusion.Abroad
+        Json.fromJson[Exclusion](JsString("Abroad")).get shouldBe Exclusion.Abroad
       }
     }
   }


### PR DESCRIPTION
* Added Exclusions to `NIResponse` to match Backend
* Added `isAbroad` to `NIReponse.NISummary` to match Backend

Still needs Exclusions for NI Record page implemented and Unit Tests for them.
Backend: https://github.com/hmrc/nisp/pull/22

FOR REVIEW ONLY DO NOT MERGE