### PR TITLE
NISP-1816 Overriding style to increase account page width to 66.666%

### DIFF
--- a/app/uk/gov/hmrc/nisp/assets/sass/nisp.scss
+++ b/app/uk/gov/hmrc/nisp/assets/sass/nisp.scss
@@ -62,6 +62,9 @@ h2.summary {
   margin-top: 0.5em;
 }
 
+.mainpage {
+  width: 66.666%;
+}
 
 /*------------------------------------*\
     #HEADER - Global Breadcrumb

--- a/app/uk/gov/hmrc/nisp/assets/sass/nisp.scss
+++ b/app/uk/gov/hmrc/nisp/assets/sass/nisp.scss
@@ -63,7 +63,9 @@ h2.summary {
 }
 
 .mainpage {
-  width: 66.666%;
+  @media only screen and (min-width: 640px) {
+    width: 66.666%;
+  }
 }
 
 /*------------------------------------*\


### PR DESCRIPTION
A simple hack to increase the width of the account page to 66.666% . I reviewed the other pages it appears they don't need to be increased to 66%, therefore only the account page has been increased.