### PR TITLE
NISP-1887: Add "year is not available" to gaps page

### DIFF
--- a/app/uk/gov/hmrc/nisp/views/nirecordpage.scala.html
+++ b/app/uk/gov/hmrc/nisp/views/nirecordpage.scala.html
@@ -125,6 +125,12 @@ authenticationProvider: String)(implicit request: Request[_], user: NispUser, pa
 <dl class="accordion">
 
     @if(niGaps) {
+        <dt>
+          <div class="ni-wrapper">
+              <div class="ni-years"> @{(tableStart)}-@{(tableStart + 1).toString.substring(2,4)}</div>
+              <div class="inactive">@Messages("nisp.nirecord.unavailableyear")</div>
+          </div>
+        </dt>
         @for(niRecordTaxYear <- niRecord.taxYears.reverse.filter(!_.qualifying)){
             @includes.nirecordtaxyear(niRecordTaxYear)
         }

--- a/app/uk/gov/hmrc/nisp/views/nirecordpage.scala.html
+++ b/app/uk/gov/hmrc/nisp/views/nirecordpage.scala.html
@@ -125,12 +125,14 @@ authenticationProvider: String)(implicit request: Request[_], user: NispUser, pa
 <dl class="accordion">
 
     @if(niGaps) {
-        <dt>
-          <div class="ni-wrapper">
-              <div class="ni-years"> @{(tableStart)}-@{(tableStart + 1).toString.substring(2,4)}</div>
-              <div class="inactive">@Messages("nisp.nirecord.unavailableyear")</div>
-          </div>
-        </dt>
+        @if(!niRecord.taxYears.exists(_.taxYear == tableStart)) {
+            <dt>
+                <div class="ni-wrapper">
+                    <div class="ni-years"> @{(tableStart)}-@{(tableStart + 1).toString.substring(2,4)}</div>
+                    <div class="inactive">@Messages("nisp.nirecord.unavailableyear")</div>
+                </div>
+            </dt>
+        }
         @for(niRecordTaxYear <- niRecord.taxYears.reverse.filter(!_.qualifying)){
             @includes.nirecordtaxyear(niRecordTaxYear)
         }


### PR DESCRIPTION
* Adds the current year is not available to the gaps page mimicking the full record
* This does not apply when the current year is posted.