### PR TITLE
NISP-2012: Replace estimate with forecast

### DIFF
--- a/app/uk/gov/hmrc/nisp/views/account.scala.html
+++ b/app/uk/gov/hmrc/nisp/views/account.scala.html
@@ -64,7 +64,7 @@
     }
     <div class="highlighted-event">
         <p>@Messages("nisp.main.basedOn") @Dates.formatDate(spSummary.statePensionAge.date.localDate)
-            @Html(Messages("nisp.main.whenYoullBe")) @spSummary.statePensionAge.age, @Messages("nisp.main.estimate").toLowerCase()
+            @Html(Messages("nisp.main.whenYoullBe")) @spSummary.statePensionAge.age, @Messages("nisp.main.caveats").toLowerCase()
             @Messages("nisp.is")
         </p>
         <p><em>@NispMoney.pounds(spSummary.forecast.forecastAmount.week) @Messages("nisp.main.week")</em></p>
@@ -75,7 +75,7 @@
 
     @if(spSummary.isMQP)  {
 
-        <p>@Messages("nisp.main.estimate")</p>
+        <p>@Messages("nisp.main.caveats")</p>
         <ul class="list-bullet">
             <li>@Messages("nisp.main.notAGuarantee")</li>
             <li>@Messages("nisp.main.isBased", Dates.formatDate(spSummary.lastProcessedDate.localDate))</li>
@@ -117,7 +117,7 @@
         }
 
         @if(spSummary.forecast.scenario.equals(Scenario.FillGaps)) {
-            <p>@Messages("nisp.main.estimate")</p>
+            <p>@Messages("nisp.main.caveats")</p>
             <ul class="list-bullet">
                 <li>@Messages("nisp.main.notAGuarantee")</li>
                 <li>@Messages("nisp.main.inflation")</li>

--- a/app/uk/gov/hmrc/nisp/views/account_forecastonly.scala.html
+++ b/app/uk/gov/hmrc/nisp/views/account_forecastonly.scala.html
@@ -48,12 +48,12 @@
 @main(userLoggedIn = true, browserTitle = Some(Messages("nisp.main.title")), pageTitle = Some(Messages("nisp.main.h1.title")), analyticsAdditionalJs = Some(analyticsAdditionalJs)) {
 
     <div class="highlighted-event">
-        <p>@Messages("nisp.main.basedOn") @Dates.formatDate(spSummary.statePensionAge.date.localDate) @Html(Messages("nisp.main.whenYoullBe")) @spSummary.statePensionAge.age, @Messages("nisp.main.estimate").toLowerCase() @Messages("nisp.is")</p>
+        <p>@Messages("nisp.main.basedOn") @Dates.formatDate(spSummary.statePensionAge.date.localDate) @Html(Messages("nisp.main.whenYoullBe")) @spSummary.statePensionAge.age, @Messages("nisp.main.caveats").toLowerCase() @Messages("nisp.is")</p>
         <p><em>@NispMoney.pounds(spSummary.forecast.forecastAmount.week) @Messages("nisp.main.week")</em></p>
         <p>@NispMoney.pounds(spSummary.forecast.forecastAmount.month) @Messages("nisp.main.month"),
         @NispMoney.pounds(spSummary.forecast.forecastAmount.year) @Messages("nisp.main.year")</p>
     </div>
-    <p>@Messages("nisp.main.estimate")</p>
+    <p>@Messages("nisp.main.caveats")</p>
     <ul class="list-bullet">
         <li>@Messages("nisp.main.notAGuarantee")</li>
         <li>@Messages("nisp.main.isBased", Dates.formatDate(spSummary.lastProcessedDate.localDate))</li>

--- a/app/uk/gov/hmrc/nisp/views/includes/continueWorking.scala.html
+++ b/app/uk/gov/hmrc/nisp/views/includes/continueWorking.scala.html
@@ -31,7 +31,7 @@
 
 } else {
 
-    <p>@Messages("nisp.main.estimate")</p>
+    <p>@Messages("nisp.main.caveats")</p>
     <ul class="list-bullet">
         <li>@Messages("nisp.main.notAGuarantee")</li>
         <li>@Messages("nisp.main.inflation")</li>

--- a/app/uk/gov/hmrc/nisp/views/includes/reached.scala.html
+++ b/app/uk/gov/hmrc/nisp/views/includes/reached.scala.html
@@ -21,7 +21,7 @@
 
 @(spSummary: SPSummaryModel)
 
-<p>@Messages("nisp.main.estimate")</p>
+<p>@Messages("nisp.main.caveats")</p>
 <ul class="list-bullet">
     <li>@Messages("nisp.main.notAGuarantee")</li>
     <li>@Messages("nisp.main.isBased",Dates.formatDate(spSummary.lastProcessedDate.localDate))</li>

--- a/conf/messages
+++ b/conf/messages
@@ -40,7 +40,7 @@ nisp.landing.signin.gg = You can sign in using the Government Gateway. You may n
 nisp.landing.signin.verify = You can also <a href="{0}" data-journey-click="checkmystatepension:landing:verifylink">sign in using GOV.UK Verify</a>. If you have not used GOV.UK Verify before, it will take you about 10 minutes to get set up. You can access other government services securely wherever you see the GOV.UK Verify logo.
 nisp.landing.sidebar.heading = Elsewhere on GOV.UK
 nisp.landing.sidebar.link1 = <a href="https://www.gov.uk/plan-retirement-income/overview" rel="external" data-journey-click="checkmystatepension:external:landingsidebarlink">Plan your retirement income</a>
-nisp.landing.estimateprovided = Your State Pension estimate is provided for your information only and the service does not offer financial advice. When planning for your retirement, you should seek professional advice.
+nisp.landing.estimateprovided = Your State Pension forecast is provided for your information only and the service does not offer financial advice. When planning for your retirement, you should seek professional advice.
 nisp.landing.eligibility.heading = You can use this service if you&rsquo;re
 nisp.landing.eligibility1 = a man born after 5 April 1951
 nisp.landing.eligibility2 = a woman born after 5 April 1953
@@ -54,16 +54,16 @@ nisp.landing.noteligible = Contact the <a href="https://www.gov.uk/future-pensio
 nisp.main.title = Summary: Check your State Pension
 nisp.main.summary = Summary
 nisp.main.h1.title = Your State Pension
-nisp.main.estimate = Your estimate
+nisp.main.caveats = Your forecast
 nisp.main.forecast = Forecast
 nisp.main.howtoincreaseit = How to increase it
 nisp.main.cope = What affects it
 nisp.main.currentvalue = Current Value
 nisp.main.today = Today, the amount of your State Pension is
 nisp.main.breakdown = Breakdown
-nisp.main.forecastonly.h2.title = Your estimate is the most you can get
+nisp.main.forecastonly.h2.title = Your forecast is the most you can get
 nisp.main.mostYouCanGet = is the most you can get
-nisp.main.cantImprove = You cannot improve your estimate any more.
+nisp.main.cantImprove = You cannot improve your forecast any more.
 nisp.main.week = a week
 nisp.main.month = a month
 nisp.main.year = a year
@@ -97,15 +97,15 @@ nisp.main.showyourrecord = View your National Insurance record
 nisp.main.showyourrecordUK = View your UK National Insurance record
 
 nisp.main.chart.lastprocessed.title= Estimate based on your National Insurance record up to 5 April {0}
-nisp.main.chart.spa.title = Estimate if you continue to contribute until April {0}
+nisp.main.chart.spa.title = Forecast if you continue to contribute until April {0}
 
 nisp.main.chart.whichis = which is
 nisp.main.chart.week = a week
 nisp.main.chart.month = a month
 nisp.main.chart.year = a year
-nisp.main.chart.estimateIfYouContinue.single = Estimate if you contribute another year before April {1}
-nisp.main.chart.estimateIfYouContinue.plural = Estimate if you contribute another {0} years before April {1}
-nisp.main.chart.estimateIfYouContinue2016 = Estimate if you contribute enough in year up to 5 April 2016
+nisp.main.chart.estimateIfYouContinue.single = Forecast if you contribute another year before April {1}
+nisp.main.chart.estimateIfYouContinue.plural = Forecast if you contribute another {0} years before April {1}
+nisp.main.chart.estimateIfYouContinue2016 = Forecast if you contribute enough in year up to 5 April 2016
 
 nisp.main.overseas = As you are living or working overseas, you may be entitled to a State Pension from the country you are living or working in. <a rel="external" target="_blank" data-journey-click="checkmystatepension:external:workingoverseas" href="https://www.gov.uk/new-state-pension/living-and-working-overseas">More information on living and working overseas (opens in new tab)</a>
 
@@ -127,14 +127,14 @@ nisp.main.context.improve.para2 = Once you have reached the full rate of £{0}, 
 nisp.main.context.forecastonly.para1 = You still need to pay National Insurance until {1} as it funds other state benefits and the NHS.
 nisp.main.context.reachMax.needToPay = You&rsquo;ll still need to pay National Insurance contributions until {0} as they fund other state benefits and the NHS.
 nisp.main.context.continueWorkingMax.stillNeedToPay = When you reach {0}, you still need to pay National Insurance until {1} as it funds other state benefits and the NHS.
-nisp.main.context.fillGaps.improve.title = You can improve your estimate
+nisp.main.context.fillGaps.improve.title = You can improve your forecast
 nisp.main.context.fillGaps.viewGaps = View gaps in your record
 
 nisp.main.context.fillGaps.viewGapsAndCost = Gaps in your record and the cost of filling them
 
 nisp.main.context.fillgaps.para1.plural = You have gaps in your National Insurance record for years where you did not contribute enough.
 nisp.main.context.fillgaps.para1.singular = You have 1 gap in your National Insurance record where you did not contribute enough. You only need to fill this gap to get the most you can.
-nisp.main.context.fillgaps.bullet1 = filling any gap can increase your estimate
+nisp.main.context.fillgaps.bullet1 = filling any gap can increase your forecast
 nisp.main.context.fillgaps.bullet2.onlyone = you only need to fill this gap to get the most you can
 nisp.main.context.fillgaps.bullet2.singular = you only need to fill 1 gap to get the most you can
 nisp.main.context.fillgaps.bullet2.plural = you only need to fill {0} gaps to get the most you can
@@ -393,7 +393,7 @@ nisp.mqp.privatePension = You may have a private pension. Use the free service t
 nisp.mqp.pensionCredit = You may be eligible for <a href="https://www.gov.uk/pension-credit/overview"  rel="external" target="_blank" data-journey-click="checkmystatepension:external:pensioncredit">Pension Credit (opens in new tab)</a> if your retirement income is low.
 nisp.mqp.moneyAdvice = Contact the <a href="https://www.moneyadviceservice.org.uk/en" rel="external" target="_blank" data-journey-click="checkmystatepension:external:moneyadvice">Money Advice Service (opens in new tab)</a> for free impartial advice.
 
-nisp.mqp.cannotImprove = You cannot improve your estimate any further, unless you choose to put off claiming. You&rsquo;ll still need to pay contributions as these fund other state benefits and the NHS.
+nisp.mqp.cannotImprove = You cannot improve your forecast any further, unless you choose to put off claiming. You&rsquo;ll still need to pay contributions as these fund other state benefits and the NHS.
 nisp.mqp.howManyToContribute = assumes that you&rsquo;ll contribute another {0}
 nisp.mqp.youCurrentlyHaveZero = You do not have any years on your record and you need at least {0} years to get any State Pension.
 nisp.mqp.youCurrentlyHave = You currently have {0} on your record and you need at least {1} years to get any State Pension.


### PR DESCRIPTION
...except when referencing 'today amount'

@dspork - I have only revised {{nisp.main.estimate}} to {{{nisp.main.caveat}}, as we already have {{nisp.main.forecast}} and it would have looked odd in the code.

@InduTest and @swaistle - all done ready for testing