### PR TITLE
Remove survey workaround | play-ui upgrade

### DIFF
--- a/app/uk/gov/hmrc/nisp/controllers/QuestionnaireController.scala
+++ b/app/uk/gov/hmrc/nisp/controllers/QuestionnaireController.scala
@@ -44,14 +44,7 @@ trait QuestionnaireController extends NispFrontendController with Actions with A
   def submit: Action[AnyContent] = UnauthorisedAction.async {
     implicit request =>
       QuestionnaireForm.form.bindFromRequest().fold(
-        formWithErrors => {
-          val replaceForm: Form[QuestionnaireForm] = {
-            formWithErrors.copy(errors = formWithErrors.errors.map { err =>
-              if(err.message == "error.maxLength") err.copy(messages = Seq("nisp.validation.summary.error.max")) else err
-            })
-          }
-          Future.successful(BadRequest(questionnaire(replaceForm)))
-        },
+        formWithErrors => Future.successful(BadRequest(questionnaire(formWithErrors))),
         value => {
           customAuditConnector.sendEvent(new QuestionnaireEvent(
             value.easyToUse,

--- a/app/uk/gov/hmrc/nisp/views/includes/questionnaireForm.scala.html
+++ b/app/uk/gov/hmrc/nisp/views/includes/questionnaireForm.scala.html
@@ -93,7 +93,7 @@
     <fieldset>
         <label for="improve" class='heading-small @if(form.errors("improve").nonEmpty) {form-field--error}'>
             @form.errors("improve").map{ error =>
-              <span class="error-notification">@Messages(error.message, error.args)</span>
+              <span class="error-notification">@Messages(error.message, error.args: _*)</span>
             }
             @Messages("nisp.questionnaire.improve.question")
             <div data-char-counter>

--- a/project/FrontendBuild.scala
+++ b/project/FrontendBuild.scala
@@ -53,7 +53,7 @@ private object AppDependencies {
     "uk.gov.hmrc" %% "play-json-logger" % "2.1.1",
     "uk.gov.hmrc" %% "play-health" % "1.1.0",
     "uk.gov.hmrc" %% "govuk-template" % "4.0.0",
-    "uk.gov.hmrc" %% "play-ui" % "4.10.0",
+    "uk.gov.hmrc" %% "play-ui" % "4.15.0",
     "uk.gov.hmrc" %% "url-builder" % "1.0.0",
     "com.kenshoo" %% "metrics-play" % "2.3.0_0.1.8",
     "uk.gov.hmrc" %% "http-caching-client" % httpCachingClientVersion,


### PR DESCRIPTION
This PR adds the ideal fix for NISP-2007 - the underlying issue was that play-ui error summary did not accept message arguments.
I raised an [issue](https://github.com/hmrc/play-ui/issues/53) for this and subsequently [fixed it](https://github.com/hmrc/play-ui/pull/54).
I've upgraded play-ui to reflect the new changes and removed the workaround.