### PR TITLE
NISP-2067: Future Proof Personal Max message

### DIFF
--- a/app/uk/gov/hmrc/nisp/config/ApplicationConfig.scala
+++ b/app/uk/gov/hmrc/nisp/config/ApplicationConfig.scala
@@ -49,6 +49,7 @@ trait ApplicationConfig {
   val pertaxFrontendUrl: String
   val breadcrumbPartialUrl: String
   val showFullNI: Boolean
+  val futureProofPersonalMax: Boolean
 }
 
 object ApplicationConfig extends ApplicationConfig with ServicesConfig {
@@ -82,5 +83,6 @@ object ApplicationConfig extends ApplicationConfig with ServicesConfig {
   private val pertaxFrontendService: String = baseUrl("pertax-frontend")
   override lazy val pertaxFrontendUrl: String = configuration.getString(s"breadcrumb-service.url").getOrElse("")
   override lazy val breadcrumbPartialUrl: String = s"$pertaxFrontendService/personal-account/integration/main-content-header"
-  override val showFullNI: Boolean = configuration.getBoolean("microservice.services.features.fullNIrecord").getOrElse(false)
+  override lazy val showFullNI: Boolean = configuration.getBoolean("microservice.services.features.fullNIrecord").getOrElse(false)
+  override lazy val futureProofPersonalMax: Boolean = configuration.getBoolean("microservice.services.features.future-proof.personalMax").getOrElse(false)
 }

--- a/app/uk/gov/hmrc/nisp/controllers/AccountController.scala
+++ b/app/uk/gov/hmrc/nisp/controllers/AccountController.scala
@@ -98,7 +98,7 @@ trait AccountController extends NispFrontendController with AuthorisedForNisp wi
               forecastChart,
               personalMaximumChart,
               isPertax,
-              futureProofPersonalMax = applicationConfig.futureProofPersonalMax && spSummary.numberOfGaps > 1
+              hidePersonalMaxYears = applicationConfig.futureProofPersonalMax && spSummary.numberOfGaps > 1
             )).withSession(storeUserInfoInSession(user, spSummary.contractedOutFlag))
           }
 

--- a/app/uk/gov/hmrc/nisp/controllers/AccountController.scala
+++ b/app/uk/gov/hmrc/nisp/controllers/AccountController.scala
@@ -91,8 +91,15 @@ trait AccountController extends NispFrontendController with AuthorisedForNisp wi
                 spSummary.forecast.forecastAmount,
                 spSummary.forecast.personalMaximum
               )
-            Ok(account(nino, spSummary, currentChart, forecastChart, personalMaximumChart, isPertax))
-               .withSession(storeUserInfoInSession(user, spSummary.contractedOutFlag))
+            Ok(account(
+              nino,
+              spSummary,
+              currentChart,
+              forecastChart,
+              personalMaximumChart,
+              isPertax,
+              futureProofPersonalMax = applicationConfig.futureProofPersonalMax && spSummary.numberOfGaps > 1
+            )).withSession(storeUserInfoInSession(user, spSummary.contractedOutFlag))
           }
 
         case SPResponseModel(_, Some(spExclusions: ExclusionsModel), _) =>

--- a/app/uk/gov/hmrc/nisp/views/account.scala.html
+++ b/app/uk/gov/hmrc/nisp/views/account.scala.html
@@ -31,7 +31,7 @@
     forecastChart: SPChartModel,
     personalMaximumChart: SPChartModel,
     isPertaxUrl:Boolean,
-    futureProofPersonalMax: Boolean
+    hidePersonalMaxYears: Boolean
 )(implicit request: Request[_], user: NispUser, partialRetriever: CachedStaticHtmlPartialRetriever)
 
 @analyticsAdditionalJs = {
@@ -133,7 +133,7 @@
                 @includes.spChart(Html(Messages("nisp.main.chart.spa.title",(spSummary.finalRelevantYear+1).toString())), forecastChart)
             }
 
-            @if(futureProofPersonalMax) {
+            @if(hidePersonalMaxYears) {
                 @includes.fillGapsFutureProof(spSummary, personalMaximumChart)
             } else {
                 @includes.fillGaps(spSummary, personalMaximumChart)

--- a/app/uk/gov/hmrc/nisp/views/account.scala.html
+++ b/app/uk/gov/hmrc/nisp/views/account.scala.html
@@ -30,7 +30,8 @@
     currentChart: SPChartModel,
     forecastChart: SPChartModel,
     personalMaximumChart: SPChartModel,
-    isPertaxUrl:Boolean
+    isPertaxUrl:Boolean,
+    futureProofPersonalMax: Boolean
 )(implicit request: Request[_], user: NispUser, partialRetriever: CachedStaticHtmlPartialRetriever)
 
 @analyticsAdditionalJs = {
@@ -132,7 +133,11 @@
                 @includes.spChart(Html(Messages("nisp.main.chart.spa.title",(spSummary.finalRelevantYear+1).toString())), forecastChart)
             }
 
-            @includes.fillGaps(spSummary, personalMaximumChart)
+            @if(futureProofPersonalMax) {
+                @includes.fillGapsFutureProof(spSummary, personalMaximumChart)
+            } else {
+                @includes.fillGaps(spSummary, personalMaximumChart)
+            }
         }
 
     }

--- a/app/uk/gov/hmrc/nisp/views/includes/fillGapsFutureProof.scala.html
+++ b/app/uk/gov/hmrc/nisp/views/includes/fillGapsFutureProof.scala.html
@@ -1,0 +1,31 @@
+@*
+* Copyright 2016 HM Revenue & Customs
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*@
+
+@import uk.gov.hmrc.nisp.models.{SPSummaryModel, SPChartModel}
+@import uk.gov.hmrc.nisp.views.formatting.{NispMoney, Time}
+@import uk.gov.hmrc.play.views.formatting.Dates
+@import uk.gov.hmrc.nisp.controllers.routes
+@import uk.gov.hmrc.nisp.utils.Constants
+
+@(spSummary: SPSummaryModel, personalMaximumChart: SPChartModel)
+
+<h2 class="heading-medium">@Messages("nisp.main.context.fillGaps.improve.title")</h2>
+
+<p>@Messages("nisp.main.context.fillgaps.futureproof.para")</p>
+
+@spChart(Html(Messages("nisp.main.context.fillgaps.futureproof.chart", spSummary.forecast.minGapsToFillToReachMaximum)), personalMaximumChart)
+
+<a href='@routes.NIRecordController.showGaps.url'>@Messages("nisp.main.context.fillGaps.viewGapsAndCost")</a>

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -101,6 +101,9 @@ microservice {
         features {
             identityVerification=true
             fullNIrecord=true
+            future-proof {
+                personalMax = false
+            }
         }
     }
 }

--- a/conf/messages
+++ b/conf/messages
@@ -139,6 +139,9 @@ nisp.main.context.fillgaps.bullet2.plural = you only need to fill {0} years to g
 nisp.main.context.fillgaps.chart.onlyone = The most you can get by filling this year in your record is
 nisp.main.context.fillgaps.chart.singular = The most you can get by filling any year in your record is
 nisp.main.context.fillgaps.chart.plural = The most you can get by filling any {0} years in your record is
+nisp.main.context.fillgaps.futureproof.para = You have years on your National Insurance record where you did not contribute enough. Filling years can improve your forecast.
+nisp.main.context.fillgaps.futureproof.chart = The most you can get is
+
 
 #**************************
 # Exclusion Messages

--- a/test/resources/fillgaps-multiple/citizen-details.json
+++ b/test/resources/fillgaps-multiple/citizen-details.json
@@ -1,0 +1,1 @@
+{"citizens":[{"nino":"<NINO>","name":{"firstName":"Dorothy","lastName":"Kovacic"},"dateOfBirth":"26121960"}],"failures":[]}

--- a/test/resources/fillgaps-multiple/nirecord.json
+++ b/test/resources/fillgaps-multiple/nirecord.json
@@ -1,0 +1,441 @@
+{
+  "niRecord": {
+    "taxYears": [
+      {
+        "taxYear": 1975,
+        "qualifying": false,
+        "classOneContributions": 0,
+        "classTwoCredits": 0,
+        "classThreeCredits": 0,
+        "otherCredits": 0,
+        "payable": false,
+        "underInvestigation": false
+      },
+      {
+        "taxYear": 1976,
+        "qualifying": false,
+        "classOneContributions": 0,
+        "classTwoCredits": 0,
+        "classThreeCredits": 0,
+        "otherCredits": 0,
+        "payable": false,
+        "underInvestigation": false
+      },
+      {
+        "taxYear": 1977,
+        "qualifying": false,
+        "classOneContributions": 0,
+        "classTwoCredits": 0,
+        "classThreeCredits": 0,
+        "otherCredits": 0,
+        "payable": false,
+        "underInvestigation": false
+      },
+      {
+        "taxYear": 1978,
+        "qualifying": false,
+        "classOneContributions": 0,
+        "classTwoCredits": 0,
+        "classThreeCredits": 0,
+        "otherCredits": 0,
+        "payable": false,
+        "underInvestigation": false
+      },
+      {
+        "taxYear": 1979,
+        "qualifying": false,
+        "classOneContributions": 0,
+        "classTwoCredits": 0,
+        "classThreeCredits": 0,
+        "otherCredits": 0,
+        "payable": false,
+        "underInvestigation": false
+      },
+      {
+        "taxYear": 1980,
+        "qualifying": false,
+        "classOneContributions": 0,
+        "classTwoCredits": 0,
+        "classThreeCredits": 0,
+        "otherCredits": 0,
+        "payable": false,
+        "underInvestigation": false
+      },
+      {
+        "taxYear": 1981,
+        "qualifying": false,
+        "classOneContributions": 0,
+        "classTwoCredits": 0,
+        "classThreeCredits": 0,
+        "otherCredits": 0,
+        "payable": false,
+        "underInvestigation": false
+      },
+      {
+        "taxYear": 1982,
+        "qualifying": false,
+        "classOneContributions": 0,
+        "classTwoCredits": 0,
+        "classThreeCredits": 0,
+        "otherCredits": 0,
+        "payable": false,
+        "underInvestigation": false
+      },
+      {
+        "taxYear": 1983,
+        "qualifying": false,
+        "classOneContributions": 0,
+        "classTwoCredits": 0,
+        "classThreeCredits": 0,
+        "otherCredits": 0,
+        "payable": false,
+        "underInvestigation": false
+      },
+      {
+        "taxYear": 1984,
+        "qualifying": false,
+        "classOneContributions": 0,
+        "classTwoCredits": 0,
+        "classThreeCredits": 0,
+        "otherCredits": 0,
+        "payable": false,
+        "underInvestigation": false
+      },
+      {
+        "taxYear": 1985,
+        "qualifying": false,
+        "classOneContributions": 0,
+        "classTwoCredits": 0,
+        "classThreeCredits": 0,
+        "otherCredits": 0,
+        "payable": false,
+        "underInvestigation": false
+      },
+      {
+        "taxYear": 1986,
+        "qualifying": false,
+        "classOneContributions": 0,
+        "classTwoCredits": 0,
+        "classThreeCredits": 0,
+        "otherCredits": 0,
+        "payable": false,
+        "underInvestigation": false
+      },
+      {
+        "taxYear": 1987,
+        "qualifying": false,
+        "classOneContributions": 0,
+        "classTwoCredits": 0,
+        "classThreeCredits": 0,
+        "otherCredits": 0,
+        "payable": false,
+        "underInvestigation": false
+      },
+      {
+        "taxYear": 1988,
+        "qualifying": false,
+        "classOneContributions": 0,
+        "classTwoCredits": 0,
+        "classThreeCredits": 0,
+        "otherCredits": 0,
+        "payable": false,
+        "underInvestigation": false
+      },
+      {
+        "taxYear": 1989,
+        "qualifying": false,
+        "classOneContributions": 0,
+        "classTwoCredits": 0,
+        "classThreeCredits": 0,
+        "otherCredits": 0,
+        "payable": false,
+        "underInvestigation": false
+      },
+      {
+        "taxYear": 1990,
+        "qualifying": false,
+        "classOneContributions": 0,
+        "classTwoCredits": 0,
+        "classThreeCredits": 0,
+        "otherCredits": 0,
+        "payable": false,
+        "underInvestigation": false
+      },
+      {
+        "taxYear": 1991,
+        "qualifying": false,
+        "classOneContributions": 0,
+        "classTwoCredits": 0,
+        "classThreeCredits": 0,
+        "otherCredits": 0,
+        "payable": false,
+        "underInvestigation": false
+      },
+      {
+        "taxYear": 1992,
+        "qualifying": false,
+        "classOneContributions": 0,
+        "classTwoCredits": 0,
+        "classThreeCredits": 0,
+        "otherCredits": 0,
+        "payable": false,
+        "underInvestigation": false
+      },
+      {
+        "taxYear": 1993,
+        "qualifying": false,
+        "classOneContributions": 0,
+        "classTwoCredits": 0,
+        "classThreeCredits": 0,
+        "otherCredits": 0,
+        "payable": false,
+        "underInvestigation": false
+      },
+      {
+        "taxYear": 1994,
+        "qualifying": false,
+        "classOneContributions": 0,
+        "classTwoCredits": 0,
+        "classThreeCredits": 0,
+        "otherCredits": 0,
+        "payable": false,
+        "underInvestigation": false
+      },
+      {
+        "taxYear": 1995,
+        "qualifying": false,
+        "classOneContributions": 0,
+        "classTwoCredits": 0,
+        "classThreeCredits": 0,
+        "otherCredits": 0,
+        "payable": false,
+        "underInvestigation": false
+      },
+      {
+        "taxYear": 1996,
+        "qualifying": false,
+        "classOneContributions": 0,
+        "classTwoCredits": 0,
+        "classThreeCredits": 0,
+        "otherCredits": 0,
+        "payable": false,
+        "underInvestigation": false
+      },
+      {
+        "taxYear": 1997,
+        "qualifying": false,
+        "classOneContributions": 0,
+        "classTwoCredits": 0,
+        "classThreeCredits": 0,
+        "otherCredits": 0,
+        "payable": false,
+        "underInvestigation": false
+      },
+      {
+        "taxYear": 1998,
+        "qualifying": false,
+        "classOneContributions": 0,
+        "classTwoCredits": 0,
+        "classThreeCredits": 0,
+        "otherCredits": 0,
+        "payable": false,
+        "underInvestigation": false
+      },
+      {
+        "taxYear": 1999,
+        "qualifying": false,
+        "classOneContributions": 0,
+        "classTwoCredits": 0,
+        "classThreeCredits": 0,
+        "otherCredits": 0,
+        "payable": false,
+        "underInvestigation": false
+      },
+      {
+        "taxYear": 2000,
+        "qualifying": false,
+        "classOneContributions": 0,
+        "classTwoCredits": 0,
+        "classThreeCredits": 0,
+        "otherCredits": 0,
+        "payable": false,
+        "underInvestigation": false
+      },
+      {
+        "taxYear": 2001,
+        "qualifying": true,
+        "classOneContributions": 0,
+        "classTwoCredits": 0,
+        "classThreeCredits": 0,
+        "otherCredits": 52,
+        "payable": false,
+        "underInvestigation": false
+      },
+      {
+        "taxYear": 2002,
+        "qualifying": true,
+        "classOneContributions": 0,
+        "classTwoCredits": 0,
+        "classThreeCredits": 0,
+        "otherCredits": 52,
+        "payable": false,
+        "underInvestigation": false
+      },
+      {
+        "taxYear": 2003,
+        "qualifying": true,
+        "classOneContributions": 0,
+        "classTwoCredits": 0,
+        "classThreeCredits": 0,
+        "otherCredits": 52,
+        "payable": false,
+        "underInvestigation": false
+      },
+      {
+        "taxYear": 2004,
+        "qualifying": true,
+        "classOneContributions": 0,
+        "classTwoCredits": 0,
+        "classThreeCredits": 0,
+        "otherCredits": 52,
+        "payable": false,
+        "underInvestigation": false
+      },
+      {
+        "taxYear": 2005,
+        "qualifying": true,
+        "classOneContributions": 0,
+        "classTwoCredits": 0,
+        "classThreeCredits": 0,
+        "otherCredits": 52,
+        "payable": false,
+        "underInvestigation": false
+      },
+      {
+        "taxYear": 2006,
+        "qualifying": true,
+        "classOneContributions": 0,
+        "classTwoCredits": 0,
+        "classThreeCredits": 0,
+        "otherCredits": 52,
+        "payable": false,
+        "underInvestigation": false
+      },
+      {
+        "taxYear": 2007,
+        "qualifying": true,
+        "classOneContributions": 0,
+        "classTwoCredits": 0,
+        "classThreeCredits": 0,
+        "otherCredits": 52,
+        "payable": false,
+        "underInvestigation": false
+      },
+      {
+        "taxYear": 2008,
+        "qualifying": false,
+        "classOneContributions": 0,
+        "classTwoCredits": 0,
+        "classThreeCredits": 0,
+        "otherCredits": 0,
+        "classThreePayable": 689,
+        "classThreePayableBy": "05/04/2019",
+        "classThreePayableByPenalty": "05/04/2023",
+        "payable": true,
+        "underInvestigation": false
+      },
+      {
+        "taxYear": 2009,
+        "qualifying": false,
+        "classOneContributions": 0,
+        "classTwoCredits": 0,
+        "classThreeCredits": 0,
+        "otherCredits": 0,
+        "classThreePayable": 689,
+        "classThreePayableBy": "05/04/2019",
+        "classThreePayableByPenalty": "05/04/2023",
+        "payable": true,
+        "underInvestigation": false
+      },
+      {
+        "taxYear": 2010,
+        "qualifying": false,
+        "classOneContributions": 0,
+        "classTwoCredits": 0,
+        "classThreeCredits": 0,
+        "otherCredits": 0,
+        "classThreePayable": 626.6,
+        "classThreePayableBy": "05/04/2019",
+        "classThreePayableByPenalty": "05/04/2023",
+        "payable": true,
+        "underInvestigation": false
+      },
+      {
+        "taxYear": 2011,
+        "qualifying": false,
+        "classOneContributions": 0,
+        "classTwoCredits": 0,
+        "classThreeCredits": 0,
+        "otherCredits": 0,
+        "classThreePayable": 655.2,
+        "classThreePayableBy": "05/04/2019",
+        "classThreePayableByPenalty": "05/04/2023",
+        "payable": true,
+        "underInvestigation": false
+      },
+      {
+        "taxYear": 2012,
+        "qualifying": false,
+        "classOneContributions": 0,
+        "classTwoCredits": 0,
+        "classThreeCredits": 0,
+        "otherCredits": 0,
+        "classThreePayable": 689,
+        "classThreePayableBy": "05/04/2019",
+        "classThreePayableByPenalty": "05/04/2023",
+        "payable": true,
+        "underInvestigation": false
+      },
+      {
+        "taxYear": 2013,
+        "qualifying": false,
+        "classOneContributions": 0,
+        "classTwoCredits": 0,
+        "classThreeCredits": 0,
+        "otherCredits": 0,
+        "classThreePayable": 704.6,
+        "classThreePayableBy": "05/04/2019",
+        "classThreePayableByPenalty": "05/04/2023",
+        "payable": true,
+        "underInvestigation": false
+      },
+      {
+        "taxYear": 2014,
+        "qualifying": false,
+        "classOneContributions": 0,
+        "classTwoCredits": 0,
+        "classThreeCredits": 0,
+        "otherCredits": 0,
+        "classThreePayable": 722.8,
+        "classThreePayableBy": "05/04/2019",
+        "classThreePayableByPenalty": "05/04/2023",
+        "payable": true,
+        "underInvestigation": false
+      }
+    ]
+  },
+  "niSummary": {
+    "noOfQualifyingYears": 12,
+    "noOfNonQualifyingYears": 33,
+    "yearsToContributeUntilPensionAge": 5,
+    "spaYear": 2020,
+    "earningsIncludedUpTo": "05/04/2015",
+    "unavailableYear": 2015,
+    "pre75QualifyingYears": 5,
+    "numberOfPayableGaps": 7,
+    "numberOfNonPayableGaps": 26,
+    "canImproveWithGaps": true,
+    "isAbroad": false,
+    "finalRelevantYear": 2019
+  }
+}

--- a/test/resources/fillgaps-multiple/summary.json
+++ b/test/resources/fillgaps-multiple/summary.json
@@ -1,0 +1,47 @@
+{
+  "spSummary": {
+    "nino": "<NINO>",
+    "lastProcessedDate": "05/04/2015",
+    "statePensionAmount": {
+      "week": 53.37,
+      "month": 232.06,
+      "year": 2784.77
+    },
+    "statePensionAge": {
+      "age": 66,
+      "date": "19/11/2020"
+    },
+    "finalRelevantYear": 2019,
+    "numberOfQualifyingYears": 12,
+    "numberOfGaps": 33,
+    "numberOfGapsPayable": 7,
+    "yearsToContributeUntilPensionAge": 5,
+    "hasPsod": false,
+    "dateOfBirth": "19/11/1954",
+    "forecast": {
+      "forecastAmount": {
+        "week": 75.6,
+        "month": 328.73,
+        "year": 3944.7
+      },
+      "yearsLeftToWork": 5,
+      "personalMaximum": {
+        "week": 106.73,
+        "month": 464.08,
+        "year": 5569.02
+      },
+      "minGapsToFillToReachMaximum": 7,
+      "scenario": "FillGaps",
+      "oldRulesCustomer": false
+    },
+    "fullNewStatePensionAmount": 155.65,
+    "contractedOutFlag": false,
+    "customerAge": 61,
+    "copeAmount": {
+      "week": 0,
+      "month": 0,
+      "year": 0
+    },
+    "isAbroad": false
+  }
+}

--- a/test/resources/fillgaps-singlegap/citizen-details.json
+++ b/test/resources/fillgaps-singlegap/citizen-details.json
@@ -1,0 +1,1 @@
+{"citizens":[{"nino":"<NINO>","name":{"firstName":"Dorothy","lastName":"Kovacic"},"dateOfBirth":"26121960"}],"failures":[]}

--- a/test/resources/fillgaps-singlegap/nirecord.json
+++ b/test/resources/fillgaps-singlegap/nirecord.json
@@ -1,0 +1,272 @@
+{
+  "niRecord": {
+    "taxYears": [
+      {
+        "taxYear": 1990,
+        "qualifying": true,
+        "classOneContributions": 0,
+        "classTwoCredits": 0,
+        "classThreeCredits": 0,
+        "otherCredits": 52,
+        "payable": false,
+        "underInvestigation": false
+      },
+      {
+        "taxYear": 1991,
+        "qualifying": true,
+        "classOneContributions": 0,
+        "classTwoCredits": 0,
+        "classThreeCredits": 0,
+        "otherCredits": 52,
+        "payable": false,
+        "underInvestigation": false
+      },
+      {
+        "taxYear": 1992,
+        "qualifying": true,
+        "classOneContributions": 0,
+        "classTwoCredits": 0,
+        "classThreeCredits": 0,
+        "otherCredits": 52,
+        "payable": false,
+        "underInvestigation": false
+      },
+      {
+        "taxYear": 1993,
+        "qualifying": true,
+        "classOneContributions": 0,
+        "classTwoCredits": 0,
+        "classThreeCredits": 0,
+        "otherCredits": 52,
+        "payable": false,
+        "underInvestigation": false
+      },
+      {
+        "taxYear": 1994,
+        "qualifying": true,
+        "classOneContributions": 0,
+        "classTwoCredits": 0,
+        "classThreeCredits": 0,
+        "otherCredits": 52,
+        "payable": false,
+        "underInvestigation": false
+      },
+      {
+        "taxYear": 1995,
+        "qualifying": true,
+        "classOneContributions": 0,
+        "classTwoCredits": 0,
+        "classThreeCredits": 0,
+        "otherCredits": 52,
+        "payable": false,
+        "underInvestigation": false
+      },
+      {
+        "taxYear": 1996,
+        "qualifying": true,
+        "classOneContributions": 525,
+        "classTwoCredits": 0,
+        "classThreeCredits": 0,
+        "otherCredits": 0,
+        "payable": false,
+        "underInvestigation": false
+      },
+      {
+        "taxYear": 1997,
+        "qualifying": true,
+        "classOneContributions": 0,
+        "classTwoCredits": 0,
+        "classThreeCredits": 0,
+        "otherCredits": 52,
+        "payable": false,
+        "underInvestigation": false
+      },
+      {
+        "taxYear": 1998,
+        "qualifying": true,
+        "classOneContributions": 0,
+        "classTwoCredits": 0,
+        "classThreeCredits": 0,
+        "otherCredits": 52,
+        "payable": false,
+        "underInvestigation": false
+      },
+      {
+        "taxYear": 1999,
+        "qualifying": true,
+        "classOneContributions": 0,
+        "classTwoCredits": 0,
+        "classThreeCredits": 0,
+        "otherCredits": 52,
+        "payable": false,
+        "underInvestigation": false
+      },
+      {
+        "taxYear": 2000,
+        "qualifying": true,
+        "classOneContributions": 0,
+        "classTwoCredits": 0,
+        "classThreeCredits": 0,
+        "otherCredits": 52,
+        "payable": false,
+        "underInvestigation": false
+      },
+      {
+        "taxYear": 2001,
+        "qualifying": true,
+        "classOneContributions": 0,
+        "classTwoCredits": 0,
+        "classThreeCredits": 0,
+        "otherCredits": 52,
+        "payable": false,
+        "underInvestigation": false
+      },
+      {
+        "taxYear": 2002,
+        "qualifying": true,
+        "classOneContributions": 0,
+        "classTwoCredits": 0,
+        "classThreeCredits": 0,
+        "otherCredits": 52,
+        "payable": false,
+        "underInvestigation": false
+      },
+      {
+        "taxYear": 2003,
+        "qualifying": true,
+        "classOneContributions": 0,
+        "classTwoCredits": 0,
+        "classThreeCredits": 0,
+        "otherCredits": 52,
+        "payable": false,
+        "underInvestigation": false
+      },
+      {
+        "taxYear": 2004,
+        "qualifying": true,
+        "classOneContributions": 0,
+        "classTwoCredits": 0,
+        "classThreeCredits": 0,
+        "otherCredits": 52,
+        "payable": false,
+        "underInvestigation": false
+      },
+      {
+        "taxYear": 2005,
+        "qualifying": true,
+        "classOneContributions": 0,
+        "classTwoCredits": 0,
+        "classThreeCredits": 0,
+        "otherCredits": 52,
+        "payable": false,
+        "underInvestigation": false
+      },
+      {
+        "taxYear": 2006,
+        "qualifying": true,
+        "classOneContributions": 0,
+        "classTwoCredits": 0,
+        "classThreeCredits": 0,
+        "otherCredits": 52,
+        "payable": false,
+        "underInvestigation": false
+      },
+      {
+        "taxYear": 2007,
+        "qualifying": true,
+        "classOneContributions": 852.43,
+        "classTwoCredits": 0,
+        "classThreeCredits": 0,
+        "otherCredits": 0,
+        "payable": false,
+        "underInvestigation": false
+      },
+      {
+        "taxYear": 2008,
+        "qualifying": true,
+        "classOneContributions": 389.4,
+        "classTwoCredits": 0,
+        "classThreeCredits": 0,
+        "otherCredits": 0,
+        "payable": false,
+        "underInvestigation": false
+      },
+      {
+        "taxYear": 2009,
+        "qualifying": true,
+        "classOneContributions": 23759.6,
+        "classTwoCredits": 0,
+        "classThreeCredits": 0,
+        "otherCredits": 0,
+        "payable": false,
+        "underInvestigation": false
+      },
+      {
+        "taxYear": 2010,
+        "qualifying": true,
+        "classOneContributions": 0,
+        "classTwoCredits": 0,
+        "classThreeCredits": 0,
+        "otherCredits": 52,
+        "payable": false,
+        "underInvestigation": false
+      },
+      {
+        "taxYear": 2011,
+        "qualifying": true,
+        "classOneContributions": 896.64,
+        "classTwoCredits": 0,
+        "classThreeCredits": 0,
+        "otherCredits": 0,
+        "payable": false,
+        "underInvestigation": false
+      },
+      {
+        "taxYear": 2012,
+        "qualifying": true,
+        "classOneContributions": 0,
+        "classTwoCredits": 0,
+        "classThreeCredits": 0,
+        "otherCredits": 0,
+        "payable": false,
+        "underInvestigation": false
+      },
+      {
+        "taxYear": 2013,
+        "qualifying": true,
+        "classOneContributions": 1020.8,
+        "classTwoCredits": 0,
+        "classThreeCredits": 0,
+        "otherCredits": 0,
+        "payable": false,
+        "underInvestigation": false
+      },
+      {
+        "taxYear": 2014,
+        "qualifying": false,
+        "classOneContributions": 0,
+        "classTwoCredits": 0,
+        "classThreeCredits": 0,
+        "otherCredits": 0,
+        "classThreePayable": 722.8,
+        "classThreePayableBy": "05/04/2019",
+        "classThreePayableByPenalty": "05/04/2023",
+        "payable": true,
+        "underInvestigation": false
+      }
+    ]
+  },
+  "niSummary": {
+    "noOfQualifyingYears": 25,
+    "noOfNonQualifyingYears": 1,
+    "yearsToContributeUntilPensionAge": 5,
+    "spaYear": 2021,
+    "earningsIncludedUpTo": "05/04/2015",
+    "unavailableYear": 2015,
+    "numberOfPayableGaps": 1,
+    "numberOfNonPayableGaps": 0,
+    "canImproveWithGaps": true,
+    "isAbroad": false,
+    "finalRelevantYear": 2019
+  }
+}

--- a/test/resources/fillgaps-singlegap/summary.json
+++ b/test/resources/fillgaps-singlegap/summary.json
@@ -1,0 +1,47 @@
+{
+  "spSummary": {
+    "nino": "<NINO>",
+    "lastProcessedDate": "05/04/2015",
+    "statePensionAmount": {
+      "week": 111.18,
+      "month": 483.43,
+      "year": 5801.21
+    },
+    "statePensionAge": {
+      "age": 66,
+      "date": "28/03/2021"
+    },
+    "finalRelevantYear": 2019,
+    "numberOfQualifyingYears": 25,
+    "numberOfGaps": 1,
+    "numberOfGapsPayable": 1,
+    "yearsToContributeUntilPensionAge": 5,
+    "hasPsod": false,
+    "dateOfBirth": "28/03/1955",
+    "forecast": {
+      "forecastAmount": {
+        "week": 134.51,
+        "month": 584.88,
+        "year": 7018.54
+      },
+      "yearsLeftToWork": 5,
+      "personalMaximum": {
+        "week": 138.49,
+        "month": 602.18,
+        "year": 7226.21
+      },
+      "minGapsToFillToReachMaximum": 1,
+      "scenario": "FillGaps",
+      "oldRulesCustomer": false
+    },
+    "fullNewStatePensionAmount": 155.65,
+    "contractedOutFlag": false,
+    "customerAge": 61,
+    "copeAmount": {
+      "week": 0,
+      "month": 0,
+      "year": 0
+    },
+    "isAbroad": false
+  }
+}

--- a/test/uk/gov/hmrc/nisp/controllers/FeedbackControllerSpec.scala
+++ b/test/uk/gov/hmrc/nisp/controllers/FeedbackControllerSpec.scala
@@ -73,6 +73,7 @@ class FeedbackControllerSpec extends UnitSpec with OneAppPerSuite with MockitoSu
       override val pertaxFrontendUrl: String = ""
       override val breadcrumbPartialUrl: String = ""
       override val showFullNI: Boolean = false
+      override val futureProofPersonalMax: Boolean = false
     }
   }
 

--- a/test/uk/gov/hmrc/nisp/controllers/LandingControllerSpec.scala
+++ b/test/uk/gov/hmrc/nisp/controllers/LandingControllerSpec.scala
@@ -63,6 +63,7 @@ class LandingControllerSpec extends UnitSpec with OneAppPerSuite {
       override val contactFormServiceIdentifier: String = ""
       override val breadcrumbPartialUrl: String = ""
       override val showFullNI: Boolean = false
+      override val futureProofPersonalMax: Boolean = false
     }
     override val identityVerificationConnector: IdentityVerificationConnector = MockIdentityVerificationConnector
 

--- a/test/uk/gov/hmrc/nisp/helpers/MockAccountController.scala
+++ b/test/uk/gov/hmrc/nisp/helpers/MockAccountController.scala
@@ -59,5 +59,6 @@ trait MockAccountController extends AccountController {
     override val contactFormServiceIdentifier: String = ""
     override val breadcrumbPartialUrl: String = ""
     override val showFullNI: Boolean = false
+    override val futureProofPersonalMax: Boolean = false
   }
 }

--- a/test/uk/gov/hmrc/nisp/helpers/MockAuthConnector.scala
+++ b/test/uk/gov/hmrc/nisp/helpers/MockAuthConnector.scala
@@ -44,7 +44,9 @@ object MockAuthConnector extends AuthConnector {
     userID("mockforecastonly") -> TestAccountBuilder.forecastOnlyNino,
     userID("mockweak") -> TestAccountBuilder.weakNino,
     userID("mockabroad") -> TestAccountBuilder.abroadNino,
-    userID("mockmqpabroad") -> TestAccountBuilder.mqpAbroadNino
+    userID("mockmqpabroad") -> TestAccountBuilder.mqpAbroadNino,
+    userID("mockfillgapsmultiple") -> TestAccountBuilder.fillGapsMultiple,
+    userID("mockfillgapssingle") -> TestAccountBuilder.fillGapSingle
   )
 
   private def payeAuthority(id: String, nino: String): Option[Authority] =

--- a/test/uk/gov/hmrc/nisp/helpers/MockBreadcrumb.scala
+++ b/test/uk/gov/hmrc/nisp/helpers/MockBreadcrumb.scala
@@ -43,5 +43,6 @@ object MockBreadcrumb extends Breadcrumb {
     override val contactFormServiceIdentifier: String = ""
     override val breadcrumbPartialUrl: String = "http://localhost:9232/account"
     override val showFullNI: Boolean = false
+    override val futureProofPersonalMax: Boolean = false
   }
 }

--- a/test/uk/gov/hmrc/nisp/helpers/MockCitizenDetailsHttp.scala
+++ b/test/uk/gov/hmrc/nisp/helpers/MockCitizenDetailsHttp.scala
@@ -39,7 +39,9 @@ object MockCitizenDetailsHttp extends UnitSpec with MockitoSugar {
     TestAccountBuilder.forecastOnlyNino,
     TestAccountBuilder.noNameNino,
     TestAccountBuilder.abroadNino,
-    TestAccountBuilder.mqpAbroadNino
+    TestAccountBuilder.mqpAbroadNino,
+    TestAccountBuilder.fillGapSingle,
+    TestAccountBuilder.fillGapsMultiple
   )
 
   def createMockedURL(nino: String, response: Future[HttpResponse]): Unit =

--- a/test/uk/gov/hmrc/nisp/helpers/MockExclusionController.scala
+++ b/test/uk/gov/hmrc/nisp/helpers/MockExclusionController.scala
@@ -51,6 +51,7 @@ object MockExclusionController extends ExclusionController {
     override val pertaxFrontendUrl: String = ""
     override val breadcrumbPartialUrl: String = ""
     override val showFullNI: Boolean = false
+    override val futureProofPersonalMax: Boolean = false
   }
   override implicit val cachedStaticHtmlPartialRetriever: CachedStaticHtmlPartialRetriever = MockCachedStaticHtmlPartialRetriever
 }

--- a/test/uk/gov/hmrc/nisp/helpers/MockNIRecordController.scala
+++ b/test/uk/gov/hmrc/nisp/helpers/MockNIRecordController.scala
@@ -59,6 +59,7 @@ trait MockNIRecordController extends NIRecordController {
     override val contactFormServiceIdentifier: String = ""
     override val breadcrumbPartialUrl: String = ""
     override val showFullNI: Boolean = true
+    override val futureProofPersonalMax: Boolean = false
   }
   override implicit val cachedStaticHtmlPartialRetriever: CachedStaticHtmlPartialRetriever = MockCachedStaticHtmlPartialRetriever
 

--- a/test/uk/gov/hmrc/nisp/helpers/MockNispHttp.scala
+++ b/test/uk/gov/hmrc/nisp/helpers/MockNispHttp.scala
@@ -35,7 +35,9 @@ object MockNispHttp extends MockitoSugar {
     TestAccountBuilder.forecastOnlyNino,
     TestAccountBuilder.invalidKeyNino,
     TestAccountBuilder.abroadNino,
-    TestAccountBuilder.mqpAbroadNino)
+    TestAccountBuilder.mqpAbroadNino,
+    TestAccountBuilder.fillGapsMultiple,
+    TestAccountBuilder.fillGapSingle)
 
   val badRequestNino = TestAccountBuilder.nonExistentNino
 

--- a/test/uk/gov/hmrc/nisp/helpers/TestAccountBuilder.scala
+++ b/test/uk/gov/hmrc/nisp/helpers/TestAccountBuilder.scala
@@ -42,6 +42,8 @@ object TestAccountBuilder {
   val weakNino: String = randomNino
   val abroadNino: String = randomNino
   val mqpAbroadNino: String = randomNino
+  val fillGapSingle: String = randomNino
+  val fillGapsMultiple: String = randomNino
 
   val mappedTestAccounts = Map(
     excludedNino -> "excluded",
@@ -54,7 +56,9 @@ object TestAccountBuilder {
     invalidKeyNino -> "invalidkey",
     noNameNino -> "noname",
     abroadNino -> "abroad",
-    mqpAbroadNino -> "mqp_abroad"
+    mqpAbroadNino -> "mqp_abroad",
+    fillGapSingle -> "fillgaps-singlegap",
+    fillGapsMultiple -> "fillgaps-multiple"
   )
 
   def jsonResponse(nino: String, api: String): HttpResponse = {


### PR DESCRIPTION
* This PR future proofs the personal max information on the account page.
* As all years are not worth the same and may not add to their pension, we can no longer say "fill any year", "you only need to fill X years". So we have removed this information
* This does not apply if you literally only have one gap in your NI Record, so they will get the regular messaging
* I have added a feature switch as we don't need this to 2017
* As this is a feature switch, I have wrote the unit tests for both situations | @swaistle, @InduTest could you look at these and see if they are enough that we don't need acceptance tests?
