### PR TITLE
NISP-2091: Enforce use of NINO type rather than String

### DIFF
--- a/app/uk/gov/hmrc/nisp/connectors/CitizenDetailsConnector.scala
+++ b/app/uk/gov/hmrc/nisp/connectors/CitizenDetailsConnector.scala
@@ -17,8 +17,9 @@
 package uk.gov.hmrc.nisp.connectors
 
 import play.api.libs.json.{JsValue, Json}
+import uk.gov.hmrc.domain.Nino
 import uk.gov.hmrc.nisp.config.wiring.WSHttp
-import uk.gov.hmrc.nisp.models.citizen.{CitizenDetailsResponse, CitizenDetailsRequest}
+import uk.gov.hmrc.nisp.models.citizen.{CitizenDetailsRequest, CitizenDetailsResponse}
 import uk.gov.hmrc.nisp.services.MetricsService
 import uk.gov.hmrc.play.http.{HeaderCarrier, HttpPost, HttpResponse}
 import uk.gov.hmrc.play.config.ServicesConfig
@@ -35,9 +36,9 @@ trait CitizenDetailsConnector {
   val serviceUrl: String
   def http: HttpPost
 
-  private def url(nino: String) = s"$serviceUrl/citizen-details/$nino/designatory-details/summary"
+  private def url(nino: Nino) = s"$serviceUrl/citizen-details/$nino/designatory-details/summary"
 
-  def connectToGetPersonDetails(nino: String)(implicit hc: HeaderCarrier): Future[CitizenDetailsResponse] = {
+  def connectToGetPersonDetails(nino: Nino)(implicit hc: HeaderCarrier): Future[CitizenDetailsResponse] = {
     val jsonRequest = Json.toJson(CitizenDetailsRequest(Set(nino)))
 
     val context = MetricsService.citizenDetailsTimer.time()

--- a/app/uk/gov/hmrc/nisp/connectors/NispConnector.scala
+++ b/app/uk/gov/hmrc/nisp/connectors/NispConnector.scala
@@ -19,18 +19,19 @@ package uk.gov.hmrc.nisp.connectors
 import play.Logger
 import play.api.data.validation.ValidationError
 import play.api.libs.json.{Format, JsPath}
+import uk.gov.hmrc.domain.Nino
 import uk.gov.hmrc.http.cache.client.SessionCache
 import uk.gov.hmrc.nisp.config.wiring.{NispSessionCache, WSHttp}
 import uk.gov.hmrc.nisp.models.enums.APIType
 import uk.gov.hmrc.nisp.models.enums.APIType.APIType
-import uk.gov.hmrc.nisp.models.{SchemeMembership, NIResponse, SPResponseModel}
+import uk.gov.hmrc.nisp.models.{NIResponse, SPResponseModel, SchemeMembership}
 import uk.gov.hmrc.nisp.services.MetricsService
 import uk.gov.hmrc.play.config.ServicesConfig
 import uk.gov.hmrc.play.http.logging.MdcLoggingExecutionContext._
 import uk.gov.hmrc.play.http.{HeaderCarrier, HttpGet, HttpResponse}
 
 import scala.concurrent.Future
-import scala.util.{Success, Try, Failure}
+import scala.util.{Failure, Success, Try}
 
 object NispConnector extends NispConnector with ServicesConfig {
   override val serviceUrl = baseUrl("nisp")
@@ -45,17 +46,17 @@ trait NispConnector {
   def serviceUrl: String
   def sessionCache: SessionCache
 
-  def connectToGetSPResponse(nino: String)(implicit hc: HeaderCarrier): Future[SPResponseModel] = {
+  def connectToGetSPResponse(nino: Nino)(implicit hc: HeaderCarrier): Future[SPResponseModel] = {
     val urlToRead = s"$serviceUrl/nisp/$nino/spsummary"
     retrieveFromCache[SPResponseModel](APIType.SP, urlToRead)
   }
 
-  def connectToGetNIResponse(nino: String)(implicit hc: HeaderCarrier): Future[NIResponse] = {
+  def connectToGetNIResponse(nino: Nino)(implicit hc: HeaderCarrier): Future[NIResponse] = {
     val urlToRead = s"$serviceUrl/nisp/$nino/nirecord"
     retrieveFromCache[NIResponse](APIType.NI, urlToRead)
   }
 
-  def connectToGetSchemeMembership(nino: String)(implicit hc: HeaderCarrier): Future[List[SchemeMembership]] = {
+  def connectToGetSchemeMembership(nino: Nino)(implicit hc: HeaderCarrier): Future[List[SchemeMembership]] = {
     val urlToRead = s"$serviceUrl/nisp/$nino/schememembership"
     retrieveFromCache[List[SchemeMembership]](APIType.SchemeMembership, urlToRead)
   }

--- a/app/uk/gov/hmrc/nisp/controllers/auth/AuthorisedForNisp.scala
+++ b/app/uk/gov/hmrc/nisp/controllers/auth/AuthorisedForNisp.scala
@@ -16,19 +16,17 @@
 
 package uk.gov.hmrc.nisp.controllers.auth
 
-import play.api.Logger
 import play.api.mvc.{Action, AnyContent, Request, Result}
-import uk.gov.hmrc.nisp.auth.{NispAuthProvider, NispCompositePageVisibilityPredicate, GovernmentGatewayProvider, VerifyProvider}
+import uk.gov.hmrc.domain.Nino
+import uk.gov.hmrc.nisp.auth.{NispAuthProvider, NispCompositePageVisibilityPredicate, VerifyProvider}
 import uk.gov.hmrc.nisp.config.ApplicationConfig
-import uk.gov.hmrc.nisp.controllers.routes
-import uk.gov.hmrc.nisp.services.{CitizenDetailsService}
+import uk.gov.hmrc.nisp.exceptions.EmptyPayeException
+import uk.gov.hmrc.nisp.services.CitizenDetailsService
 import uk.gov.hmrc.nisp.utils.Constants
 import uk.gov.hmrc.play.frontend.auth._
-import uk.gov.hmrc.play.frontend.auth.connectors.domain.{ConfidenceLevel, Accounts}
-import uk.gov.hmrc.play.frontend.auth.connectors.domain.ConfidenceLevel.L200
-import uk.gov.hmrc.play.frontend.controller.UnauthorisedAction
-import uk.gov.hmrc.play.http.{SessionKeys, HeaderCarrier}
+import uk.gov.hmrc.play.frontend.auth.connectors.domain.{Accounts, ConfidenceLevel}
 import uk.gov.hmrc.play.http.logging.MdcLoggingExecutionContext._
+import uk.gov.hmrc.play.http.{HeaderCarrier, SessionKeys}
 
 import scala.concurrent.Future
 
@@ -81,10 +79,10 @@ trait AuthorisedForNisp extends Actions {
     }
   }
 
-  private def retrieveNino(principal: Principal): String = {
+  private def retrieveNino(principal: Principal): Nino = {
     principal.accounts.paye match {
-      case Some(account) => account.nino.toString()
-      case None => Logger.warn("User Paye account is empty"); ""
+      case Some(account) => account.nino
+      case None => throw new EmptyPayeException("PAYE Account is empty")
     }
   }
 

--- a/app/uk/gov/hmrc/nisp/controllers/auth/NispUser.scala
+++ b/app/uk/gov/hmrc/nisp/controllers/auth/NispUser.scala
@@ -17,11 +17,13 @@
 package uk.gov.hmrc.nisp.controllers.auth
 
 import org.joda.time.DateTime
+import uk.gov.hmrc.domain.Nino
+import uk.gov.hmrc.nisp.exceptions.EmptyPayeException
 import uk.gov.hmrc.nisp.utils.Constants
 import uk.gov.hmrc.play.frontend.auth.AuthContext
 
 case class NispUser(authContext: AuthContext, name: Option[String], authProvider: String) {
-  def nino: Option[String] = authContext.principal.accounts.paye.map(_.nino.nino)
+  def nino: Nino = authContext.principal.accounts.paye.map(_.nino).getOrElse(throw new EmptyPayeException("AuthContext does not have PAYE Details"))
   def previouslyLoggedInAt: Option[DateTime] = authContext.user.previouslyLoggedInAt
   val authProviderOld = if(authContext.user.confidenceLevel.level == 500) Constants.verify else Constants.iv
   val confidenceLevel = authContext.user.confidenceLevel

--- a/app/uk/gov/hmrc/nisp/exceptions/EmptyPayeException.scala
+++ b/app/uk/gov/hmrc/nisp/exceptions/EmptyPayeException.scala
@@ -14,12 +14,6 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.nisp.models.citizen
+package uk.gov.hmrc.nisp.exceptions
 
-import play.api.libs.json.{Format, Json}
-import uk.gov.hmrc.domain.Nino
-
-case class CitizenDetailsRequest(ninos:Set[Nino])
-object CitizenDetailsRequest{
-  implicit val formats: Format[CitizenDetailsRequest] = Json.format[CitizenDetailsRequest]
-}
+class EmptyPayeException(val message: String) extends Exception(message)

--- a/app/uk/gov/hmrc/nisp/models/SPSummaryModel.scala
+++ b/app/uk/gov/hmrc/nisp/models/SPSummaryModel.scala
@@ -16,10 +16,9 @@
 
 package uk.gov.hmrc.nisp.models
 
-import uk.gov.hmrc.nisp.models.enums.MQPScenario.MQPScenario
-import uk.gov.hmrc.nisp.models.enums.SPContextMessage
-import SPContextMessage.SPContextMessage
 import play.api.libs.json.Json
+import uk.gov.hmrc.nisp.models.enums.MQPScenario.MQPScenario
+import uk.gov.hmrc.nisp.models.enums.SPContextMessage.SPContextMessage
 
 case class SPSummaryModel( nino: String,
                            lastProcessedDate: NpsDate,

--- a/app/uk/gov/hmrc/nisp/models/citizen/Citizen.scala
+++ b/app/uk/gov/hmrc/nisp/models/citizen/Citizen.scala
@@ -17,8 +17,9 @@
 package uk.gov.hmrc.nisp.models.citizen
 
 import play.api.libs.json.Json
+import uk.gov.hmrc.domain.Nino
 
-case class Citizen(nino:String, name: Option[CidName]=None, dateOfBirth: Option[String]=None) {
+case class Citizen(nino: Nino, name: Option[CidName]=None, dateOfBirth: Option[String]=None) {
   def getNameFormatted: Option[String] = {
     name match {
       case Some(CidName(Some(firstName), Some(lastName))) => Some("%s %s".format(firstName, lastName))

--- a/app/uk/gov/hmrc/nisp/services/CitizenDetailsService.scala
+++ b/app/uk/gov/hmrc/nisp/services/CitizenDetailsService.scala
@@ -17,8 +17,9 @@
 package uk.gov.hmrc.nisp.services
 
 import play.api.Logger
+import uk.gov.hmrc.domain.Nino
 import uk.gov.hmrc.nisp.connectors.CitizenDetailsConnector
-import uk.gov.hmrc.nisp.models.citizen.{Citizen, CitizenDetailsResponse}
+import uk.gov.hmrc.nisp.models.citizen.Citizen
 import uk.gov.hmrc.play.http.HeaderCarrier
 import uk.gov.hmrc.play.http.logging.MdcLoggingExecutionContext._
 
@@ -31,7 +32,7 @@ object CitizenDetailsService extends CitizenDetailsService {
 trait CitizenDetailsService {
   val citizenDetailsConnector: CitizenDetailsConnector
 
-  def retrievePerson(nino: String)(implicit hc: HeaderCarrier): Future[Option[Citizen]] = {
+  def retrievePerson(nino: Nino)(implicit hc: HeaderCarrier): Future[Option[Citizen]] = {
     citizenDetailsConnector.connectToGetPersonDetails(nino) map(_.citizens.headOption) recover {
       case ex =>
         Logger.error(s"Citizen details returned error: ${ex.toString}")

--- a/app/uk/gov/hmrc/nisp/views/account.scala.html
+++ b/app/uk/gov/hmrc/nisp/views/account.scala.html
@@ -25,7 +25,6 @@
 
 
 @(
-    nino: String,
     spSummary: SPSummaryModel,
     currentChart: SPChartModel,
     forecastChart: SPChartModel,

--- a/app/uk/gov/hmrc/nisp/views/account_cope.scala.html
+++ b/app/uk/gov/hmrc/nisp/views/account_cope.scala.html
@@ -23,7 +23,7 @@
 @import uk.gov.hmrc.play.partials.CachedStaticHtmlPartialRetriever
 @import uk.gov.hmrc.nisp.models.NpsDate
 
-@(nino: String, forecastAmount: BigDecimal, copeEstimate: BigDecimal, totalPension: BigDecimal, isPertaxUrl:Boolean, schemeMembership: List[SchemeMembership])(implicit request: Request[_], user: NispUser, partialRetriever: CachedStaticHtmlPartialRetriever)
+@(forecastAmount: BigDecimal, copeEstimate: BigDecimal, totalPension: BigDecimal, isPertaxUrl:Boolean, schemeMembership: List[SchemeMembership])(implicit request: Request[_], user: NispUser, partialRetriever: CachedStaticHtmlPartialRetriever)
 
 @sidebar = {
 <div class="helpline-sidebar" >

--- a/app/uk/gov/hmrc/nisp/views/account_cope_old.scala.html
+++ b/app/uk/gov/hmrc/nisp/views/account_cope_old.scala.html
@@ -22,7 +22,7 @@
 @import uk.gov.hmrc.nisp.controllers.auth.NispUser
 @import uk.gov.hmrc.play.partials.CachedStaticHtmlPartialRetriever
 
-@(nino: String, forecastAmount: BigDecimal, copeEstimate: BigDecimal, totalPension: BigDecimal, isPertaxUrl:Boolean)(implicit request: Request[_], user: NispUser, partialRetriever: CachedStaticHtmlPartialRetriever)
+@(forecastAmount: BigDecimal, copeEstimate: BigDecimal, totalPension: BigDecimal, isPertaxUrl:Boolean)(implicit request: Request[_], user: NispUser, partialRetriever: CachedStaticHtmlPartialRetriever)
 
 @sidebar = {
 <div class="helpline-sidebar" >

--- a/app/uk/gov/hmrc/nisp/views/account_forecastonly.scala.html
+++ b/app/uk/gov/hmrc/nisp/views/account_forecastonly.scala.html
@@ -22,7 +22,7 @@
 @import uk.gov.hmrc.nisp.controllers.auth.NispUser
 @import uk.gov.hmrc.play.partials.CachedStaticHtmlPartialRetriever
 
-@(nino: String, spSummary: SPSummaryModel, isPertaxUrl:Boolean)(implicit request: Request[_], user: NispUser, partialRetriever: CachedStaticHtmlPartialRetriever)
+@(spSummary: SPSummaryModel, isPertaxUrl:Boolean)(implicit request: Request[_], user: NispUser, partialRetriever: CachedStaticHtmlPartialRetriever)
 
 @sidebar = {
 <div class="helpline-sidebar" >

--- a/app/uk/gov/hmrc/nisp/views/account_mqp.scala.html
+++ b/app/uk/gov/hmrc/nisp/views/account_mqp.scala.html
@@ -25,7 +25,7 @@
 @import uk.gov.hmrc.play.http.logging.MdcLoggingExecutionContext._
 @import uk.gov.hmrc.play.partials.CachedStaticHtmlPartialRetriever
 
-@(nino: String, spSummary: SPSummaryModel, mqp: Option[MQPScenario], numberOfYearsMissing: Int,
+@(spSummary: SPSummaryModel, mqp: Option[MQPScenario], numberOfYearsMissing: Int,
   isPertaxUrl:Boolean)(implicit request: Request[_], user: NispUser, partialRetriever: CachedStaticHtmlPartialRetriever)
 
 @sidebar = {

--- a/app/uk/gov/hmrc/nisp/views/excluded_ni.scala.html
+++ b/app/uk/gov/hmrc/nisp/views/excluded_ni.scala.html
@@ -19,7 +19,7 @@
 @import uk.gov.hmrc.nisp.controllers.auth.NispUser
 @import uk.gov.hmrc.play.partials.CachedStaticHtmlPartialRetriever
 
-@(nino: String, niExclusions: ExclusionsModel)(implicit request: Request[_], user: NispUser,
+@(niExclusions: ExclusionsModel)(implicit request: Request[_], user: NispUser,
 partialRetriever: CachedStaticHtmlPartialRetriever)
 
 @analyticsAdditionalJs = {

--- a/app/uk/gov/hmrc/nisp/views/excluded_sp_old.scala.html
+++ b/app/uk/gov/hmrc/nisp/views/excluded_sp_old.scala.html
@@ -21,7 +21,7 @@
 @import uk.gov.hmrc.play.partials.CachedStaticHtmlPartialRetriever
 @import exclusions.viewExclusions
 
-@(nino: String, spExclusions: ExclusionsModel, statePensionAge: SPAgeModel)(implicit request: Request[_], user: NispUser,
+@(spExclusions: ExclusionsModel, statePensionAge: SPAgeModel)(implicit request: Request[_], user: NispUser,
   partialRetriever: CachedStaticHtmlPartialRetriever)
 
 @analyticsAdditionalJs = {

--- a/app/uk/gov/hmrc/nisp/views/nirecordpage.scala.html
+++ b/app/uk/gov/hmrc/nisp/views/nirecordpage.scala.html
@@ -24,7 +24,7 @@
 @import uk.gov.hmrc.nisp.config.ApplicationConfig
 @import org.joda.time.LocalDate
 
-@(nino: String, niRecord: NIRecord, niSummary: NISummary, niGaps: Boolean = false, tableStart: Int, recordEnded: Boolean,
+@(niRecord: NIRecord, niSummary: NISummary, niGaps: Boolean = false, tableStart: Int, recordEnded: Boolean,
 authenticationProvider: String, showFullNI: Boolean, currentDate: LocalDate)(implicit request: Request[_], user: NispUser, partialRetriever: CachedStaticHtmlPartialRetriever)
 
 @sidebar = {

--- a/test/uk/gov/hmrc/nisp/connectors/NispConnectorSpec.scala
+++ b/test/uk/gov/hmrc/nisp/connectors/NispConnectorSpec.scala
@@ -37,7 +37,7 @@ class NispConnectorSpec extends UnitSpec with MockitoSugar with  BeforeAndAfter 
   val cachedUserId = UserId(s"/auth/oid/$cachedNinoAndUsername")
 
   def spSummary: SPSummaryModel = SPSummaryModel(
-    TestAccountBuilder.regularNino,
+    TestAccountBuilder.regularNino.nino,
     NpsDate(2014,4,5),
     SPAmountModel(150.26,653.36,7840.35),
     SPAgeModel(66,NpsDate(2027,9,26)),
@@ -100,7 +100,7 @@ class NispConnectorSpec extends UnitSpec with MockitoSugar with  BeforeAndAfter 
 
     "return cached SPResponse if existing" in {
       MockNispConnector.connectToGetSPResponse(cachedNinoAndUsername)(new HeaderCarrier(userId = Some(cachedUserId))).spSummary
-        .map(_.copy(nino = TestAccountBuilder.regularNino)) shouldBe Some(spSummary)
+        .map(_.copy(nino = TestAccountBuilder.regularNino.nino)) shouldBe Some(spSummary)
     }
   }
 

--- a/test/uk/gov/hmrc/nisp/helpers/MockAuthConnector.scala
+++ b/test/uk/gov/hmrc/nisp/helpers/MockAuthConnector.scala
@@ -50,10 +50,10 @@ object MockAuthConnector extends AuthConnector {
     userID("mockfillgapssingle") -> TestAccountBuilder.fillGapSingle
   )
 
-  private def payeAuthority(id: String, nino: String): Option[Authority] =
-    Some(Authority(id, Accounts(paye = Some(PayeAccount(s"/paye/$nino", Nino(nino)))), None, None, testCredentialStrength(nino), L500, None, None))
+  private def payeAuthority(id: String, nino: Nino): Option[Authority] =
+    Some(Authority(id, Accounts(paye = Some(PayeAccount(s"/paye/$nino", nino))), None, None, testCredentialStrength(nino), L500, None, None))
 
-  private def testCredentialStrength(nino: String): CredentialStrength =
+  private def testCredentialStrength(nino: Nino): CredentialStrength =
     if (nino == TestAccountBuilder.weakNino) CredentialStrength.Weak else CredentialStrength.Strong
 
   override def currentAuthority(implicit hc: HeaderCarrier): Future[Option[Authority]] =

--- a/test/uk/gov/hmrc/nisp/helpers/MockCitizenDetailsHttp.scala
+++ b/test/uk/gov/hmrc/nisp/helpers/MockCitizenDetailsHttp.scala
@@ -20,8 +20,9 @@ import org.mockito.Matchers
 import org.mockito.Mockito._
 import org.scalatest.mock.MockitoSugar
 import play.api.http.Status
-import play.api.libs.json.{Json, JsValue}
-import uk.gov.hmrc.play.http.{BadRequestException, NotFoundException, HttpResponse, HttpPost}
+import play.api.libs.json.{JsValue, Json}
+import uk.gov.hmrc.domain.Nino
+import uk.gov.hmrc.play.http.{BadRequestException, HttpPost, HttpResponse, NotFoundException}
 import uk.gov.hmrc.play.test.UnitSpec
 
 import scala.concurrent.Future
@@ -45,11 +46,11 @@ object MockCitizenDetailsHttp extends UnitSpec with MockitoSugar {
     TestAccountBuilder.fillGapsMultiple
   )
 
-  def createMockedURL(nino: String, response: Future[HttpResponse]): Unit =
+  def createMockedURL(nino: Nino, response: Future[HttpResponse]): Unit =
     when(mockHttp.POST[JsValue, HttpResponse](Matchers.endsWith(s"citizen-details/$nino/designatory-details/summary"), Matchers.any(),
       Matchers.any())(Matchers.any(), Matchers.any(), Matchers.any())).thenReturn(response)
 
-  private def setupCitizenDetailsMocking(nino: String) =
+  private def setupCitizenDetailsMocking(nino: Nino) =
     createMockedURL(nino, TestAccountBuilder.jsonResponse(nino, "citizen-details"))
 
   ninos.foreach(setupCitizenDetailsMocking)

--- a/test/uk/gov/hmrc/nisp/helpers/MockNispHttp.scala
+++ b/test/uk/gov/hmrc/nisp/helpers/MockNispHttp.scala
@@ -19,6 +19,7 @@ package uk.gov.hmrc.nisp.helpers
 import org.mockito.Matchers
 import org.mockito.Mockito._
 import org.scalatest.mock.MockitoSugar
+import uk.gov.hmrc.domain.Nino
 import uk.gov.hmrc.play.http.{BadRequestException, HttpGet, HttpResponse}
 
 import scala.concurrent.Future
@@ -48,7 +49,7 @@ object MockNispHttp extends MockitoSugar {
   def createFailedMockedURL(urlEndsWith: String): Unit =
     when(mockHttp.GET[HttpResponse](Matchers.endsWith(urlEndsWith))(Matchers.any(), Matchers.any())).thenReturn(Future.failed(new BadRequestException("")))
 
-  def setupNinoEndpoints(nino: String): Unit = {
+  def setupNinoEndpoints(nino: Nino): Unit = {
     createMockedURL(s"nisp/$nino/spsummary", TestAccountBuilder.jsonResponse(nino, "summary"))
     createMockedURL(s"nisp/$nino/nirecord", TestAccountBuilder.jsonResponse(nino, "nirecord"))
     createMockedURL(s"nisp/$nino/schememembership", TestAccountBuilder.jsonResponse(nino, "schememembership"))

--- a/test/uk/gov/hmrc/nisp/helpers/TestAccountBuilder.scala
+++ b/test/uk/gov/hmrc/nisp/helpers/TestAccountBuilder.scala
@@ -18,7 +18,7 @@ package uk.gov.hmrc.nisp.helpers
 
 import play.api.http.Status
 import play.api.libs.json.Json
-import uk.gov.hmrc.domain.Generator
+import uk.gov.hmrc.domain.{Generator, Nino}
 import uk.gov.hmrc.play.http.HttpResponse
 
 import scala.io.Source
@@ -26,26 +26,26 @@ import scala.util.Random
 
 object TestAccountBuilder {
 
-  def randomNino: String = new Generator(new Random()).nextNino.nino.replaceFirst("MA", "AA")
+  def randomNino: Nino = Nino(new Generator(new Random()).nextNino.nino.replaceFirst("MA", "AA"))
 
-  val nonExistentNino: String = randomNino
-  val excludedNino: String = randomNino
-  val regularNino: String = randomNino
-  val mqpNino: String = randomNino
-  val forecastOnlyNino: String = randomNino
-  val contractedOutBTestNino: String = randomNino.replaceAll("[02468]", "1")
-  val fullUserNino: String = randomNino
-  val blankNino: String = randomNino
-  val notFoundNino: String = randomNino
-  val invalidKeyNino: String = randomNino
-  val cachedNino: String = randomNino
-  val noNameNino: String = randomNino
-  val weakNino: String = randomNino
-  val abroadNino: String = randomNino
-  val mqpAbroadNino: String = randomNino
-  val hrpNino: String = randomNino
-  val fillGapSingle: String = randomNino
-  val fillGapsMultiple: String = randomNino
+  val nonExistentNino: Nino = randomNino
+  val excludedNino: Nino = randomNino
+  val regularNino: Nino = randomNino
+  val mqpNino: Nino = randomNino
+  val forecastOnlyNino: Nino = randomNino
+  val contractedOutBTestNino: Nino = Nino(randomNino.nino.replaceAll("[02468]", "1"))
+  val fullUserNino: Nino = randomNino
+  val blankNino: Nino = randomNino
+  val notFoundNino: Nino = randomNino
+  val invalidKeyNino: Nino = randomNino
+  val cachedNino: Nino = randomNino
+  val noNameNino: Nino = randomNino
+  val weakNino: Nino = randomNino
+  val abroadNino: Nino = randomNino
+  val mqpAbroadNino: Nino = randomNino
+  val hrpNino: Nino = randomNino
+  val fillGapSingle: Nino = randomNino
+  val fillGapsMultiple: Nino = randomNino
 
   val mappedTestAccounts = Map(
     excludedNino -> "excluded",
@@ -64,9 +64,9 @@ object TestAccountBuilder {
     fillGapsMultiple -> "fillgaps-multiple"
   )
 
-  def jsonResponse(nino: String, api: String): HttpResponse = {
+  def jsonResponse(nino: Nino, api: String): HttpResponse = {
     val jsonFile = fileContents(s"test/resources/${mappedTestAccounts(nino)}/$api.json")
-    HttpResponse(Status.OK, Some(Json.parse(jsonFile.replace("<NINO>", nino))))
+    HttpResponse(Status.OK, Some(Json.parse(jsonFile.replace("<NINO>", nino.nino))))
   }
 
   private def fileContents(filename: String): String = Source.fromFile(filename).mkString


### PR DESCRIPTION
This PR at it's core switches the NINO in NispUser to `Nino` from the domain library instead of `Option[String]`. This will help enforce programmatically that the  service cannot work without a NINO on the user's account.
When the PAYE Account / NINO is pulled from the AuthContext a custom exception is now thrown instead.

I have also removed the use of `user.nino` in some of the views as it did nothing. If it needs to be there, it is available in the NispUser object.