### PR TITLE
Update auth-login-stub to new URL

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -118,7 +118,7 @@ contact-frontend {
 }
 
 government-gateway-sign-in {
-    host="http://localhost:9949/gg/sign-in"
+    host="http://localhost:9949/auth-login-stub/gg-sign-in"
 }
 
 two-factor {

--- a/test/uk/gov/hmrc/nisp/controllers/AccountControllerSpec.scala
+++ b/test/uk/gov/hmrc/nisp/controllers/AccountControllerSpec.scala
@@ -58,7 +58,7 @@ class AccountControllerSpec extends UnitSpec with MockitoSugar with BeforeAndAft
   val mockUserIdFillGapsSingle = "/auth/oid/mockfillgapssingle"
   val mockUserIdFillGapsMultiple = "/auth/oid/mockfillgapsmultiple"
 
-  val ggSignInUrl = "http://localhost:9949/gg/sign-in?continue=http%3A%2F%2Flocalhost%3A9234%2Fcheck-your-state-pension%2Faccount&origin=nisp-frontend&accountType=individual"
+  val ggSignInUrl = "http://localhost:9949/auth-login-stub/gg-sign-in?continue=http%3A%2F%2Flocalhost%3A9234%2Fcheck-your-state-pension%2Faccount&origin=nisp-frontend&accountType=individual"
   val twoFactorUrl = "http://localhost:9949/coafe/two-step-verification/register/?continue=http%3A%2F%2Flocalhost%3A9234%2Fcheck-your-state-pension%2Faccount&failure=http%3A%2F%2Flocalhost%3A9234%2Fcheck-your-state-pension%2Fnot-authorised"
 
   lazy val fakeRequest = FakeRequest()

--- a/test/uk/gov/hmrc/nisp/controllers/NIRecordControllerSpec.scala
+++ b/test/uk/gov/hmrc/nisp/controllers/NIRecordControllerSpec.scala
@@ -44,7 +44,7 @@ class NIRecordControllerSpec extends UnitSpec with OneAppPerSuite {
   val mockUserIdHRP = "/auth/oid/mockhomeresponsibilitiesprotection"
   val mockUserWithGaps ="/auth/oid/mockfillgapsmultiple"
 
-  val ggSignInUrl = s"http://localhost:9949/gg/sign-in?continue=http%3A%2F%2Flocalhost%3A9234%2Fcheck-your-state-pension%2Faccount&origin=nisp-frontend&accountType=individual"
+  val ggSignInUrl = s"http://localhost:9949/auth-login-stub/gg-sign-in?continue=http%3A%2F%2Flocalhost%3A9234%2Fcheck-your-state-pension%2Faccount&origin=nisp-frontend&accountType=individual"
 
   lazy val fakeRequest = FakeRequest()
   def authenticatedFakeRequest(userId: String) = FakeRequest().withSession(


### PR DESCRIPTION
Changing the gg login URL from a deprecated one

I had to drop my local mongo databases to get this to work.
