### PR TITLE
NISP-2105 Added functionality to display breadcrumb when user's name is not available. 

### DIFF
--- a/app/uk/gov/hmrc/nisp/utils/Breadcrumb.scala
+++ b/app/uk/gov/hmrc/nisp/utils/Breadcrumb.scala
@@ -50,10 +50,17 @@ trait Breadcrumb {
     initialBreadCrumbList ::: items.flatten
   }
 
-  def generateHeaderUrl(hideBreadcrumb: Boolean = false) (implicit request:Request[_], user: NispUser): String = {
-    mainContentHeaderPartialUrl + "?name=" + s"${URLEncoder.encode(user.name.getOrElse(""),"UTF-8")}" + "&" +
-      user.previouslyLoggedInAt.map("lastLogin=" + _.getMillis + "&").getOrElse("") +
-      (if(hideBreadcrumb) "" else buildBreadCrumb(request).map{case (name: String, url: String) => s"item_text=$name&item_url=$url"}.mkString("&")) +
-      "&showBetaBanner=true&deskProToken='NISP'"
+  def generateHeaderUrl(hideBreadcrumb: Boolean = false) (implicit request:Request[_], user: NispUser): String =  {
+    if(user.name.isDefined) {
+        mainContentHeaderPartialUrl + "?name=" + s"${URLEncoder.encode(user.name.getOrElse(""), "UTF-8")}" + "&" +
+          user.previouslyLoggedInAt.map("lastLogin=" + _.getMillis + "&").getOrElse("") +
+          (if (hideBreadcrumb) "" else buildBreadCrumb(request).map { case (name: String, url: String) => s"item_text=$name&item_url=$url" }.mkString("&")) +
+          "&showBetaBanner=true&deskProToken='NISP'"
+    }
+    else {
+        mainContentHeaderPartialUrl + "?" + user.previouslyLoggedInAt.map("lastLogin=" + _.getMillis + "&").getOrElse("") +
+          (if (hideBreadcrumb) "" else buildBreadCrumb(request).map { case (name: String, url: String) => s"item_text=$name&item_url=$url" }.mkString("&")) +
+          "&showBetaBanner=true&deskProToken='NISP'"
+    }
   }
 }

--- a/app/uk/gov/hmrc/nisp/utils/Breadcrumb.scala
+++ b/app/uk/gov/hmrc/nisp/utils/Breadcrumb.scala
@@ -51,16 +51,13 @@ trait Breadcrumb {
   }
 
   def generateHeaderUrl(hideBreadcrumb: Boolean = false) (implicit request:Request[_], user: NispUser): String =  {
-    if(user.name.isDefined) {
-        mainContentHeaderPartialUrl + "?name=" + s"${URLEncoder.encode(user.name.getOrElse(""), "UTF-8")}" + "&" +
-          user.previouslyLoggedInAt.map("lastLogin=" + _.getMillis + "&").getOrElse("") +
-          (if (hideBreadcrumb) "" else buildBreadCrumb(request).map { case (name: String, url: String) => s"item_text=$name&item_url=$url" }.mkString("&")) +
-          "&showBetaBanner=true&deskProToken='NISP'"
-    }
-    else {
-        mainContentHeaderPartialUrl + "?" + user.previouslyLoggedInAt.map("lastLogin=" + _.getMillis + "&").getOrElse("") +
-          (if (hideBreadcrumb) "" else buildBreadCrumb(request).map { case (name: String, url: String) => s"item_text=$name&item_url=$url" }.mkString("&")) +
-          "&showBetaBanner=true&deskProToken='NISP'"
-    }
+
+    val name: String =  if(user.name.isDefined) {"?name=" + s"${URLEncoder.encode(user.name.getOrElse(""), "UTF-8")}"} else "?"
+    val lastLogin =  user.previouslyLoggedInAt.map("lastLogin=" + _.getMillis + "&").getOrElse("")
+    val showBreadcrumb = if (hideBreadcrumb) "" else  { buildBreadCrumb(request).map {
+        case (name: String, url: String) => s"item_text=$name&item_url=$url" }.mkString("&")} +
+              "&showBetaBanner=true&deskProToken='NISP'"
+    mainContentHeaderPartialUrl.concat(name).concat(lastLogin).concat(showBreadcrumb)
+
   }
 }

--- a/app/uk/gov/hmrc/nisp/utils/Breadcrumb.scala
+++ b/app/uk/gov/hmrc/nisp/utils/Breadcrumb.scala
@@ -51,13 +51,14 @@ trait Breadcrumb {
   }
 
   def generateHeaderUrl(hideBreadcrumb: Boolean = false) (implicit request:Request[_], user: NispUser): String =  {
-
-    val name: String =  if(user.name.isDefined) {"?name=" + s"${URLEncoder.encode(user.name.getOrElse(""), "UTF-8")}"} else "?"
+    val name: String =  user.name.map("?name=" + URLEncoder.encode(_,"UTF-8") + "&").getOrElse("?")
     val lastLogin =  user.previouslyLoggedInAt.map("lastLogin=" + _.getMillis + "&").getOrElse("")
     val showBreadcrumb = if (hideBreadcrumb) "" else  { buildBreadCrumb(request).map {
-        case (name: String, url: String) => s"item_text=$name&item_url=$url" }.mkString("&")} +
-              "&showBetaBanner=true&deskProToken='NISP'"
-    mainContentHeaderPartialUrl.concat(name).concat(lastLogin).concat(showBreadcrumb)
+        case (name: String, url: String) => s"item_text=$name&item_url=$url" }.mkString("&")}
+    val showBetaBanner = "&showBetaBanner=true&deskProToken='NISP'"
+    mainContentHeaderPartialUrl.concat(name).concat(lastLogin).concat(showBreadcrumb).concat(showBetaBanner)
+
+
 
   }
 }

--- a/test/uk/gov/hmrc/nisp/utils/BreadcrumbSpec.scala
+++ b/test/uk/gov/hmrc/nisp/utils/BreadcrumbSpec.scala
@@ -37,6 +37,9 @@ class BreadcrumbSpec extends UnitSpec with OneAppPerSuite {
   val nispUser: NispUser = {
     new NispUser(authContext, Some("testName"), "testAuthProvider",Some("M"))
   }
+  val emptyNispUser: NispUser = {
+    new NispUser(authContext, None, "testAuthProvider",Some("M"))
+  }
 
   "Breadcrumb utils" should {
     "return a item text as Account Home and State Pension" in {
@@ -45,6 +48,18 @@ class BreadcrumbSpec extends UnitSpec with OneAppPerSuite {
       MockBreadcrumb.generateHeaderUrl()(fakeRequestSP, nispUser) should not include ("NI+record")
       MockBreadcrumb.generateHeaderUrl()(fakeRequestSP, nispUser) should not include "Voluntary+contributions"
       MockBreadcrumb.generateHeaderUrl()(fakeRequestSP, nispUser) should not include "Gaps+in+your+record"
+    }
+
+    "return an item text without a 'name' variable, when user.name has no value" in {
+      MockBreadcrumb.generateHeaderUrl()(fakeRequestSP, emptyNispUser) should not include ("account?name=")
+    }
+
+    "return an item text with no 'name' variable, when user.name has no value" in {
+      MockBreadcrumb.generateHeaderUrl()(fakeRequestSP, emptyNispUser) should include ("account?item_text")
+    }
+
+    "return an item text with users' name, when user.name has value " in {
+      MockBreadcrumb.generateHeaderUrl()(fakeRequestSP, nispUser) should include ("account?name=" + nispUser.name.get)
     }
 
     "return a item text as Account Home, State Pension and NI Record when URL is /account/nirecord/gaps" in {

--- a/test/uk/gov/hmrc/nisp/utils/BreadcrumbSpec.scala
+++ b/test/uk/gov/hmrc/nisp/utils/BreadcrumbSpec.scala
@@ -50,16 +50,12 @@ class BreadcrumbSpec extends UnitSpec with OneAppPerSuite {
       MockBreadcrumb.generateHeaderUrl()(fakeRequestSP, nispUser) should not include "Gaps+in+your+record"
     }
 
-    "return an item text without a 'name' variable, when user.name has no value" in {
-      MockBreadcrumb.generateHeaderUrl()(fakeRequestSP, emptyNispUser) should not include ("account?name=")
+    "return a breadcrumb url without a 'name' variable, when user.name has no value" in {
+      MockBreadcrumb.generateHeaderUrl()(fakeRequestSP, emptyNispUser) should not include ("name=")
     }
 
-    "return an item text with no 'name' variable, when user.name has no value" in {
-      MockBreadcrumb.generateHeaderUrl()(fakeRequestSP, emptyNispUser) should include ("account?item_text")
-    }
-
-    "return an item text with users' name, when user.name has value " in {
-      MockBreadcrumb.generateHeaderUrl()(fakeRequestSP, nispUser) should include ("account?name=" + nispUser.name.get)
+    "return a breadcrumb url with users' name, when user.name has value " in {
+      MockBreadcrumb.generateHeaderUrl()(fakeRequestSP, nispUser) should include ("name=" + nispUser.name.get)
     }
 
     "return a item text as Account Home, State Pension and NI Record when URL is /account/nirecord/gaps" in {


### PR DESCRIPTION
Also added further tests for this situation.

What I have done

- I have added a switch depending on whether the users' name is available. If it is, then the full breadcrumb is specified; if not, then the breadcrumb is missing the ```name``` parameter.

-Added 3 tests that check whether the breadcrumb url provided changes, based on whether users' name is empty or not.