### PR TITLE
NISP-2110 Updating NPM packages to the latest versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,15 +2,15 @@
   "name": "nisp-frontend",
   "version": "0.0.0",
   "devDependencies": {
-    "grunt": "~0.4.5",
-    "grunt-cli": "~0.1.13",
-    "grunt-contrib-sass": "~0.9.2",
-    "grunt-plato": "~1.2.1",
-    "grunt-scss-lint": "^0.3.8"
+    "grunt": "1.0.1",
+    "grunt-cli": "1.2.0",
+    "grunt-contrib-sass": "1.0.0",
+    "grunt-plato": "1.4.0",
+    "grunt-scss-lint": "0.5.0"
   },
   "dependencies": {
-    "grunt-contrib-watch": "~0.6.1",
-    "grunt-scss-lint": "~0.3.4",
-    "grunt-contrib-clean": "~0.6.0"
+    "grunt-contrib-watch": "1.0.0",
+    "grunt-scss-lint": "0.5.0",
+    "grunt-contrib-clean": "1.0.0"
   }
 }


### PR DESCRIPTION
To re-install the latest packages in your local machine, delete ``node_modules`` directory and run ``npm install``.  
