### PR TITLE
Refactor AccountController.showCope to use abstraction layer

### DIFF
--- a/app/uk/gov/hmrc/nisp/controllers/ExclusionController.scala
+++ b/app/uk/gov/hmrc/nisp/controllers/ExclusionController.scala
@@ -41,9 +41,13 @@ trait ExclusionController extends NispFrontendController with AuthorisedForNisp 
   val statePensionService: StatePensionService
 
   def showSP: Action[AnyContent] = AuthorisedByAny.async { implicit user => implicit request =>
+
+    val statePensionF = statePensionService.getSummary(user.nino)
+    val niResponseF = nispConnector.connectToGetNIResponse(user.nino)
+
     for(
-      statePension <- statePensionService.getSummary(user.nino);
-      niResponse <- nispConnector.connectToGetNIResponse(user.nino)
+      statePension <- statePensionF;
+      niResponse <- niResponseF
     ) yield {
       statePension match {
         case Left(exclusion) =>

--- a/app/uk/gov/hmrc/nisp/models/StatePension.scala
+++ b/app/uk/gov/hmrc/nisp/models/StatePension.scala
@@ -49,7 +49,10 @@ case class StatePension(earningsIncludedUpTo: LocalDate,
                         finalRelevantYear: String,
                         numberOfQualifyingYears: Int,
                         pensionSharingOrder: Boolean,
-                        currentFullWeeklyPensionAmount: BigDecimal)
+                        currentFullWeeklyPensionAmount: BigDecimal) {
+
+  val contractedOut: Boolean = amounts.cope.weeklyAmount > 0
+}
 
 object StatePension {
   implicit val formats = Json.format[StatePension]

--- a/app/uk/gov/hmrc/nisp/services/StatePensionService.scala
+++ b/app/uk/gov/hmrc/nisp/services/StatePensionService.scala
@@ -58,7 +58,13 @@ trait NispConnection {
             spSummary.forecast.personalMaximum.week,
             spSummary.forecast.personalMaximum.month,
             spSummary.forecast.personalMaximum.year),
-          cope = StatePensionAmount(None, None, 0, 0, 0)
+          cope = StatePensionAmount(
+            None,
+            None,
+            spSummary.copeAmount.week,
+            spSummary.copeAmount.month,
+            spSummary.copeAmount.year
+          )
         ),
         pensionAge = spSummary.statePensionAge.age,
         pensionDate = spSummary.statePensionAge.date.localDate,

--- a/app/uk/gov/hmrc/nisp/views/account_cope.scala.html
+++ b/app/uk/gov/hmrc/nisp/views/account_cope.scala.html
@@ -23,7 +23,7 @@
 @import uk.gov.hmrc.play.partials.CachedStaticHtmlPartialRetriever
 @import uk.gov.hmrc.nisp.models.NpsDate
 
-@(forecastAmount: BigDecimal, copeEstimate: BigDecimal, totalPension: BigDecimal, isPertaxUrl:Boolean, schemeMembership: List[SchemeMembership])(implicit request: Request[_], user: NispUser, partialRetriever: CachedStaticHtmlPartialRetriever)
+@(copeEstimate: BigDecimal, isPertaxUrl:Boolean, schemeMembership: List[SchemeMembership])(implicit request: Request[_], user: NispUser, partialRetriever: CachedStaticHtmlPartialRetriever)
 
 @sidebar = {
 <div class="helpline-sidebar" >

--- a/app/uk/gov/hmrc/nisp/views/account_cope_old.scala.html
+++ b/app/uk/gov/hmrc/nisp/views/account_cope_old.scala.html
@@ -22,7 +22,7 @@
 @import uk.gov.hmrc.nisp.controllers.auth.NispUser
 @import uk.gov.hmrc.play.partials.CachedStaticHtmlPartialRetriever
 
-@(forecastAmount: BigDecimal, copeEstimate: BigDecimal, totalPension: BigDecimal, isPertaxUrl:Boolean)(implicit request: Request[_], user: NispUser, partialRetriever: CachedStaticHtmlPartialRetriever)
+@(copeEstimate: BigDecimal, isPertaxUrl:Boolean)(implicit request: Request[_], user: NispUser, partialRetriever: CachedStaticHtmlPartialRetriever)
 
 @sidebar = {
 <div class="helpline-sidebar" >

--- a/test/uk/gov/hmrc/nisp/helpers/MockAccountController.scala
+++ b/test/uk/gov/hmrc/nisp/helpers/MockAccountController.scala
@@ -21,7 +21,7 @@ import uk.gov.hmrc.nisp.config.ApplicationConfig
 import uk.gov.hmrc.nisp.connectors.NispConnector
 import uk.gov.hmrc.nisp.controllers.AccountController
 import uk.gov.hmrc.nisp.controllers.connectors.CustomAuditConnector
-import uk.gov.hmrc.nisp.services.{MetricsService}
+import uk.gov.hmrc.nisp.services.{MetricsService, StatePensionService}
 import uk.gov.hmrc.play.frontend.auth.connectors.AuthConnector
 import uk.gov.hmrc.play.partials.CachedStaticHtmlPartialRetriever
 
@@ -37,6 +37,7 @@ trait MockAccountController extends AccountController {
   override val metricsService: MetricsService = MockMetricsService
 
   override def nispConnector: NispConnector = MockNispConnector
+  override val statePensionService: StatePensionService = MockStatePensionService
   override val applicationConfig: ApplicationConfig = new ApplicationConfig {
     override val assetsPrefix: String = ""
     override val reportAProblemNonJSUrl: String = ""

--- a/test/uk/gov/hmrc/nisp/models/StatePensionSpec.scala
+++ b/test/uk/gov/hmrc/nisp/models/StatePensionSpec.scala
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2016 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.nisp.models
+
+import org.joda.time._
+
+import uk.gov.hmrc.play.test.UnitSpec
+
+class StatePensionSpec extends UnitSpec {
+
+  "contractedOut" should {
+    "return true when the user has a COPE amount more than 0" in {
+      StatePension(
+        new LocalDate(2016, 4, 5),
+        amounts = StatePensionAmounts (
+          false,
+          StatePensionAmount(None, None, 0, 0, 0),
+          StatePensionAmount(None, None, 0, 0, 0),
+          StatePensionAmount(None, None, 0, 0, 0),
+          cope = StatePensionAmount(None, None, 0.87, 26.48, 317.77)
+        ),
+        65,
+        new LocalDate(2019, 5, 1),
+        "2018-19",
+        30,
+        false,
+        155.65
+      ).contractedOut shouldBe true
+    }
+    "return false when the user has a COPE amount of 0" in {
+      StatePension(
+        new LocalDate(2016, 4, 5),
+        amounts = StatePensionAmounts (
+          false,
+          StatePensionAmount(None, None, 0, 0, 0),
+          StatePensionAmount(None, None, 0, 0, 0),
+          StatePensionAmount(None, None, 0, 0, 0),
+          cope = StatePensionAmount(None, None, 0, 0, 0)
+        ),
+        65,
+        new LocalDate(2019, 5, 1),
+        "2018-19",
+        30,
+        false,
+        155.65
+      ).contractedOut shouldBe false
+    }
+  }
+
+}


### PR DESCRIPTION
- AccountController.showCope now uses `StatePensionService`
- Left copeTable functionality in for now, will need to be removed on nisp deconstruction
- Add a `contractedOut` boolean to the `StatePension` Model.
- Add a `StatePension` Model Spec
- Updated Exclusion Controller to properly use futures.
