### PR TITLE
NISP-2257: Remove Summary

### DIFF
--- a/app/uk/gov/hmrc/nisp/views/account.scala.html
+++ b/app/uk/gov/hmrc/nisp/views/account.scala.html
@@ -76,12 +76,6 @@
         sidebarLinks = Some(sidebar),
         articleClasses = Some("mainpage"), analyticsAdditionalJs = Some(analyticsAdditionalJs)) {
     
-    @if(statePension.mqpScenario.isEmpty &&
-        (statePension.forecastScenario.equals(Scenario.FillGaps) ||
-         statePension.forecastScenario.equals(Scenario.ContinueWorkingMax) ||
-         statePension.forecastScenario.equals(Scenario.ContinueWorkingNonMax))) {
-        <h2 class="heading-medium summary">@Messages("nisp.main.summary")</h2>
-    }
     <div class="highlighted-event">
         <p>@Messages("nisp.main.basedOn") <span class="nowrap">@Dates.formatDate(statePension.pensionDate)</span>
             @Html(Messages("nisp.main.whenYoullBe")) @statePension.pensionAge, <span class="nowrap">@Messages("nisp.main.caveats").toLowerCase()

--- a/conf/messages
+++ b/conf/messages
@@ -54,7 +54,6 @@ nisp.landing.noteligible = Contact the <a href="https://www.gov.uk/future-pensio
 #**************************
 
 nisp.main.title = Summary: Check your State Pension
-nisp.main.summary = Summary
 nisp.main.h1.title = Your State Pension
 nisp.main.caveats = Your forecast
 nisp.main.forecast = Forecast


### PR DESCRIPTION
@Shaju-11 and @InduTest - I have removed:
- summary from messages 
- code from main page that displays the message (Continue and Continue with gaps scenarios)

@prashantchoudhari and @nehakannaujia - the code only has some deletions, so should be straightforward to check.