### PR TITLE
NISP-1833: Graph font size change for Mobile device

### DIFF
--- a/app/uk/gov/hmrc/nisp/assets/sass/nisp.scss
+++ b/app/uk/gov/hmrc/nisp/assets/sass/nisp.scss
@@ -257,10 +257,19 @@ textarea {
       text-align: right;
       font-size: 1.3em;
       font-weight: 800;
+      @media only screen and (min-width: 749px) and (max-width:948px) {
+                min-width:40%;
+            }
+      @media only screen and (min-width: 641px) and (max-width:748px) {
+                            min-width:48%;
+                        }
       @media only screen and (max-width: 640px) {
-        font-size: 0.8em;
+        font-size: 1em;
         line-height: 2em;
       }
+      @media only screen and (max-width: 398px) {
+              min-width:40%;
+            }
       & > * {
         padding-right: 10px;
       }      


### PR DESCRIPTION
font size of graph text is increased from .8em to 1 em for mobile devices.
