### PR TITLE
NISP-2302: Fixed country code 0 incorrectly triggering overseas Bug

### DIFF
--- a/app/uk/gov/hmrc/nisp/utils/Country.scala
+++ b/app/uk/gov/hmrc/nisp/utils/Country.scala
@@ -19,6 +19,7 @@ package uk.gov.hmrc.nisp.utils
 object Country {
 
   def isAbroad(countryName: String): Boolean = {
+
     countryName match {
       case GREAT_BRITAIN => false
       case ISLE_OF_MAN=> false
@@ -26,6 +27,7 @@ object Country {
       case SCOTLAND => false
       case WALES => false
       case NORTHERN_IRELAND => false
+      case NOT_SPECIFIED  => false
       case _ => true
     }
   }
@@ -36,5 +38,6 @@ object Country {
   final val SCOTLAND = "SCOTLAND"
   final val WALES = "WALES"
   final val NORTHERN_IRELAND = "NORTHERN IRELAND"
+  final val NOT_SPECIFIED = "NOT SPECIFIED OR NOT USED"
 
 }

--- a/app/uk/gov/hmrc/nisp/views/account_forecastonly.scala.html
+++ b/app/uk/gov/hmrc/nisp/views/account_forecastonly.scala.html
@@ -77,7 +77,7 @@ yearsToContributeUntilPensionAge: Int)(implicit request: Request[_], user: NispU
         <li>@Messages("nisp.main.inflation")</li>
         @if(statePension.pensionSharingOrder) {<li>@Messages("nisp.main.psod")</li>}
     </ul>
-    <h2 class="heading-medium">@NispMoney.pounds(statePension.amounts.forecast.weeklyAmount) @Messages("dd")</h2>
+    <h2 class="heading-medium">@NispMoney.pounds(statePension.amounts.forecast.weeklyAmount) @Messages("nisp.main.mostYouCanGet")</h2>
     <p>@Messages("nisp.main.cantImprove")</p>
     <p>@Html(Messages("nisp.main.context.reachMax.needToPay", statePension.finalRelevantEndYear.toString()))</p>
     <a href='@routes.NIRecordController.showFull.url'>@Messages("nisp.main.showyourrecord")</a>

--- a/app/uk/gov/hmrc/nisp/views/account_forecastonly.scala.html
+++ b/app/uk/gov/hmrc/nisp/views/account_forecastonly.scala.html
@@ -77,7 +77,7 @@ yearsToContributeUntilPensionAge: Int)(implicit request: Request[_], user: NispU
         <li>@Messages("nisp.main.inflation")</li>
         @if(statePension.pensionSharingOrder) {<li>@Messages("nisp.main.psod")</li>}
     </ul>
-    <h2 class="heading-medium">@NispMoney.pounds(statePension.amounts.forecast.weeklyAmount) @Messages("nisp.main.mostYouCanGet")</h2>
+    <h2 class="heading-medium">@NispMoney.pounds(statePension.amounts.forecast.weeklyAmount) @Messages("dd")</h2>
     <p>@Messages("nisp.main.cantImprove")</p>
     <p>@Html(Messages("nisp.main.context.reachMax.needToPay", statePension.finalRelevantEndYear.toString()))</p>
     <a href='@routes.NIRecordController.showFull.url'>@Messages("nisp.main.showyourrecord")</a>

--- a/test/uk/gov/hmrc/nisp/connectors/IdentityVerificationConnectorSpec.scala
+++ b/test/uk/gov/hmrc/nisp/connectors/IdentityVerificationConnectorSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 HM Revenue & Customs
+ * Copyright 2017 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/nisp/connectors/NispConnectorSpec.scala
+++ b/test/uk/gov/hmrc/nisp/connectors/NispConnectorSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 HM Revenue & Customs
+ * Copyright 2017 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/nisp/connectors/StatePensionConnectorSpec.scala
+++ b/test/uk/gov/hmrc/nisp/connectors/StatePensionConnectorSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 HM Revenue & Customs
+ * Copyright 2017 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/nisp/controllers/AccountControllerSpec.scala
+++ b/test/uk/gov/hmrc/nisp/controllers/AccountControllerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 HM Revenue & Customs
+ * Copyright 2017 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/nisp/controllers/ExclusionControllerSpec.scala
+++ b/test/uk/gov/hmrc/nisp/controllers/ExclusionControllerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 HM Revenue & Customs
+ * Copyright 2017 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/nisp/controllers/FeedbackControllerSpec.scala
+++ b/test/uk/gov/hmrc/nisp/controllers/FeedbackControllerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 HM Revenue & Customs
+ * Copyright 2017 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/nisp/controllers/LandingControllerSpec.scala
+++ b/test/uk/gov/hmrc/nisp/controllers/LandingControllerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 HM Revenue & Customs
+ * Copyright 2017 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/nisp/controllers/NIRecordControllerSpec.scala
+++ b/test/uk/gov/hmrc/nisp/controllers/NIRecordControllerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 HM Revenue & Customs
+ * Copyright 2017 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/nisp/controllers/QuestionnaireControllerSpec.scala
+++ b/test/uk/gov/hmrc/nisp/controllers/QuestionnaireControllerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 HM Revenue & Customs
+ * Copyright 2017 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/nisp/controllers/RedirectControllerSpec.scala
+++ b/test/uk/gov/hmrc/nisp/controllers/RedirectControllerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 HM Revenue & Customs
+ * Copyright 2017 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/nisp/controllers/TermsConditionsControllerSpec.scala
+++ b/test/uk/gov/hmrc/nisp/controllers/TermsConditionsControllerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 HM Revenue & Customs
+ * Copyright 2017 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/nisp/controllers/auth/NispUserSpec.scala
+++ b/test/uk/gov/hmrc/nisp/controllers/auth/NispUserSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 HM Revenue & Customs
+ * Copyright 2017 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/nisp/events/QuestionnaireEventSpec.scala
+++ b/test/uk/gov/hmrc/nisp/events/QuestionnaireEventSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 HM Revenue & Customs
+ * Copyright 2017 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/nisp/helpers/MockAccountController.scala
+++ b/test/uk/gov/hmrc/nisp/helpers/MockAccountController.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 HM Revenue & Customs
+ * Copyright 2017 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/nisp/helpers/MockAuthConnector.scala
+++ b/test/uk/gov/hmrc/nisp/helpers/MockAuthConnector.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 HM Revenue & Customs
+ * Copyright 2017 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/nisp/helpers/MockBreadcrumb.scala
+++ b/test/uk/gov/hmrc/nisp/helpers/MockBreadcrumb.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 HM Revenue & Customs
+ * Copyright 2017 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/nisp/helpers/MockCachedStaticHtmlPartialRetriever.scala
+++ b/test/uk/gov/hmrc/nisp/helpers/MockCachedStaticHtmlPartialRetriever.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 HM Revenue & Customs
+ * Copyright 2017 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/nisp/helpers/MockCitizenDetailsConnector.scala
+++ b/test/uk/gov/hmrc/nisp/helpers/MockCitizenDetailsConnector.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 HM Revenue & Customs
+ * Copyright 2017 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/nisp/helpers/MockCitizenDetailsHttp.scala
+++ b/test/uk/gov/hmrc/nisp/helpers/MockCitizenDetailsHttp.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 HM Revenue & Customs
+ * Copyright 2017 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/nisp/helpers/MockCitizenDetailsService.scala
+++ b/test/uk/gov/hmrc/nisp/helpers/MockCitizenDetailsService.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 HM Revenue & Customs
+ * Copyright 2017 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/nisp/helpers/MockCustomAuditConnector.scala
+++ b/test/uk/gov/hmrc/nisp/helpers/MockCustomAuditConnector.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 HM Revenue & Customs
+ * Copyright 2017 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/nisp/helpers/MockExclusionController.scala
+++ b/test/uk/gov/hmrc/nisp/helpers/MockExclusionController.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 HM Revenue & Customs
+ * Copyright 2017 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/nisp/helpers/MockFormPartialRetriever.scala
+++ b/test/uk/gov/hmrc/nisp/helpers/MockFormPartialRetriever.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 HM Revenue & Customs
+ * Copyright 2017 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/nisp/helpers/MockIdentityVerificationConnector.scala
+++ b/test/uk/gov/hmrc/nisp/helpers/MockIdentityVerificationConnector.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 HM Revenue & Customs
+ * Copyright 2017 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/nisp/helpers/MockIdentityVerificationHttp.scala
+++ b/test/uk/gov/hmrc/nisp/helpers/MockIdentityVerificationHttp.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 HM Revenue & Customs
+ * Copyright 2017 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/nisp/helpers/MockMetricsService.scala
+++ b/test/uk/gov/hmrc/nisp/helpers/MockMetricsService.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 HM Revenue & Customs
+ * Copyright 2017 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/nisp/helpers/MockNIRecordController.scala
+++ b/test/uk/gov/hmrc/nisp/helpers/MockNIRecordController.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 HM Revenue & Customs
+ * Copyright 2017 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/nisp/helpers/MockNispConnector.scala
+++ b/test/uk/gov/hmrc/nisp/helpers/MockNispConnector.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 HM Revenue & Customs
+ * Copyright 2017 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/nisp/helpers/MockNispHttp.scala
+++ b/test/uk/gov/hmrc/nisp/helpers/MockNispHttp.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 HM Revenue & Customs
+ * Copyright 2017 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/nisp/helpers/MockSessionCache.scala
+++ b/test/uk/gov/hmrc/nisp/helpers/MockSessionCache.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 HM Revenue & Customs
+ * Copyright 2017 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/nisp/helpers/MockStatePensionConnector.scala
+++ b/test/uk/gov/hmrc/nisp/helpers/MockStatePensionConnector.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 HM Revenue & Customs
+ * Copyright 2017 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/nisp/helpers/MockStatePensionService.scala
+++ b/test/uk/gov/hmrc/nisp/helpers/MockStatePensionService.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 HM Revenue & Customs
+ * Copyright 2017 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/nisp/helpers/TestAccountBuilder.scala
+++ b/test/uk/gov/hmrc/nisp/helpers/TestAccountBuilder.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 HM Revenue & Customs
+ * Copyright 2017 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/nisp/models/NIRecordTaxYearSpec.scala
+++ b/test/uk/gov/hmrc/nisp/models/NIRecordTaxYearSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 HM Revenue & Customs
+ * Copyright 2017 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/nisp/models/NpsDateSpec.scala
+++ b/test/uk/gov/hmrc/nisp/models/NpsDateSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 HM Revenue & Customs
+ * Copyright 2017 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/nisp/models/SchemeMembershipSpec.scala
+++ b/test/uk/gov/hmrc/nisp/models/SchemeMembershipSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 HM Revenue & Customs
+ * Copyright 2017 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/nisp/models/StatePensionSpec.scala
+++ b/test/uk/gov/hmrc/nisp/models/StatePensionSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 HM Revenue & Customs
+ * Copyright 2017 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/nisp/models/enums/SPExclusionSpec.scala
+++ b/test/uk/gov/hmrc/nisp/models/enums/SPExclusionSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 HM Revenue & Customs
+ * Copyright 2017 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/nisp/services/CitizenDetailsServiceSpec.scala
+++ b/test/uk/gov/hmrc/nisp/services/CitizenDetailsServiceSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 HM Revenue & Customs
+ * Copyright 2017 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/nisp/services/StatePensionServiceSpec.scala
+++ b/test/uk/gov/hmrc/nisp/services/StatePensionServiceSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 HM Revenue & Customs
+ * Copyright 2017 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/nisp/utils/BreadcrumbSpec.scala
+++ b/test/uk/gov/hmrc/nisp/utils/BreadcrumbSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 HM Revenue & Customs
+ * Copyright 2017 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/nisp/utils/CountrySpec.scala
+++ b/test/uk/gov/hmrc/nisp/utils/CountrySpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 HM Revenue & Customs
+ * Copyright 2017 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -46,6 +46,10 @@ class CountrySpec extends UnitSpec {
 
     "should return false if the Country is WALES" in {
      Country.isAbroad("WALES") shouldBe false
+    }
+
+    "should return false if the Country is NOT SPECIFIED OR NOT USED" in {
+      Country.isAbroad("NOT SPECIFIED OR NOT USED") shouldBe false
     }
 
   }

--- a/test/uk/gov/hmrc/nisp/views/formatting/NispMoneySpec.scala
+++ b/test/uk/gov/hmrc/nisp/views/formatting/NispMoneySpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 HM Revenue & Customs
+ * Copyright 2017 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/nisp/views/formatting/TimeSpec.scala
+++ b/test/uk/gov/hmrc/nisp/views/formatting/TimeSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 HM Revenue & Customs
+ * Copyright 2017 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
This issue is fixed. Now if the country is not specified, user will not be treated as overseas.