### PR TITLE
NISP-2379: Remove reference to State Pension age from Too Old Exclusion

### DIFF
--- a/app/uk/gov/hmrc/nisp/views/excluded_sp.scala.html
+++ b/app/uk/gov/hmrc/nisp/views/excluded_sp.scala.html
@@ -50,7 +50,7 @@ canSeeNIRecord: Boolean
            date <- statePensionAgeDate
         ) {
             @if(exclusionReasons.contains(PostStatePensionAge)) {
-                <h2 class="heading-medium"> @Messages("nisp.excluded.haveReached", Dates.formatDate(date), age) </h2>
+                <h2 class="heading-medium"> @Messages("nisp.excluded.haveReached", Dates.formatDate(date)) </h2>
             } else {
                 <h2 class="heading-medium"> @Html(Messages("nisp.excluded.willReach", Dates.formatDate(date))) </h2>
             }

--- a/conf/messages
+++ b/conf/messages
@@ -191,7 +191,7 @@ nisp.excluded.spa = If you have not already started <a href="https://www.gov.uk/
 nisp.excluded.spa.nirecord = You can <a href="https://www.gov.uk/check-national-insurance-record" rel="external" data-journey-click="checkmystatepension:external:checkyournationalinsurancerecord" target="_blank">check your National Insurance record (opens in new tab)</a>.
 nisp.excluded.niRecordIntro = See a record of the National Insurance contributions which count towards your State Pension and check for any gaps.
 nisp.excluded.niRecordIntroUK = See a record of the UK National Insurance contributions which count towards your UK State Pension and check for any gaps.
-nisp.excluded.haveReached = You reached State Pension age on {0} when you were {1}
+nisp.excluded.haveReached = You reached State Pension age on {0}
 nisp.excluded.willReach = You&rsquo;ll reach State Pension age on <span class="nowrap">{0}</span>.
 
 nisp.excluded.helpUs.title = Help us improve this service

--- a/test/uk/gov/hmrc/nisp/views/VoluntaryContributionsViewSpec.scala
+++ b/test/uk/gov/hmrc/nisp/views/VoluntaryContributionsViewSpec.scala
@@ -14,22 +14,6 @@
  * limitations under the License.
  */
 
-/*
- * Copyright 2017 HM Revenue & Customs
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package uk.gov.hmrc.nisp.views
 
 import org.scalatest._


### PR DESCRIPTION
@dspork, @prashantchoudhari and @nehadotkannaujia - just a minor amendment to the messages file.

@swaistle and @Shaju-11 - all ready to test