### PR TITLE
NISP-2414: Citizen Details Parser to use 2 schemas

### DIFF
--- a/app/uk/gov/hmrc/nisp/models/citizen/Citizen.scala
+++ b/app/uk/gov/hmrc/nisp/models/citizen/Citizen.scala
@@ -33,15 +33,16 @@ case class Citizen(nino: Nino, firstName: Option[String] = None, lastName: Optio
 
 object Citizen {
 
-  val dateReads = Reads[LocalDate]( value => value.validate[Long].map(new LocalDate(_)))
-  val dateWrites = Writes[LocalDate](date => Json.toJson(date.toDateTimeAtStartOfDay.getMillis))
-  val dateFormats: Format[LocalDate] = Format(dateReads, dateWrites)
+  implicit val dateReads: Reads[LocalDate] = Reads[LocalDate] {
+    case value: JsNumber => value.validate[Long].map(new LocalDate(_))
+    case value => value.validate[String].map(LocalDate.parse)
+  }
 
   implicit val formats: Format[Citizen] = (
       (__ \ "nino").format[Nino] and
       (__ \ "firstName").format[Option[String]] and
       (__ \ "lastName").format[Option[String]] and
       (__ \ "sex").format[Option[String]] and
-      (__ \ "dateOfBirth").format[LocalDate](dateFormats)
+      (__ \ "dateOfBirth").format[LocalDate]
     ) (Citizen.apply, unlift(Citizen.unapply))
 }

--- a/test/uk/gov/hmrc/nisp/models/CitizenDetailsResponseSpec.scala
+++ b/test/uk/gov/hmrc/nisp/models/CitizenDetailsResponseSpec.scala
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2017 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.nisp.models
+
+import org.joda.time.LocalDate
+import play.api.libs.json.Json
+import uk.gov.hmrc.nisp.helpers.TestAccountBuilder
+import uk.gov.hmrc.nisp.models.citizen.{Address, Citizen, CitizenDetailsResponse}
+import uk.gov.hmrc.play.test.UnitSpec
+
+
+class CitizenDetailsResponseSpec extends UnitSpec {
+    "Citizen" should {
+
+      val nino = TestAccountBuilder.regularNino
+      val citizenDetailsResponse = CitizenDetailsResponse(
+        Citizen(
+          nino,
+          Some("AHMED"),
+          Some("BRENNAN"),
+          Some("M"),
+          new LocalDate(1954, 3, 9)
+        ),
+        Some(Address(
+          country = Some("USA")
+        ))
+      )
+
+      "parse correctly when date of birth is a date" in {
+        Json.parse(
+          s"""
+            |{
+            |  "etag":"1",
+            |  "person":{
+            |    "sex":"M",
+            |    "dateOfBirth":-499132800000,
+            |    "nino":"$nino",
+            |    "firstName":"AHMED",
+            |    "middleName":"",
+            |    "lastName":"BRENNAN",
+            |    "title":"Mrs",
+            |    "honours":null
+            |  },
+            |  "address":{
+            |    "line1":"108 SAI ROAD",
+            |    "line2":"",
+            |    "line3":"",
+            |    "line4":null,
+            |    "postcode":"12345",
+            |    "country":"USA",
+            |    "startDate":1223510400000,
+            |    "type":"Residential"
+            |  }
+            |}
+          """.stripMargin
+        ).as[CitizenDetailsResponse] shouldBe citizenDetailsResponse
+      }
+
+      "parse correctly when date of birth is a long" in {
+        Json.parse(
+          s"""
+             |{
+             |  "etag":"1",
+             |  "person":{
+             |    "sex":"M",
+             |    "dateOfBirth":"1954-03-09",
+             |    "nino":"$nino",
+             |    "firstName":"AHMED",
+             |    "middleName":"",
+             |    "lastName":"BRENNAN",
+             |    "title":"Mrs",
+             |    "honours":null
+             |  },
+             |  "address":{
+             |    "line1":"108 SAI ROAD",
+             |    "line2":"",
+             |    "line3":"",
+             |    "line4":null,
+             |    "postcode":"12345",
+             |    "country":"USA",
+             |    "startDate":1223510400000,
+             |    "type":"Residential"
+             |  }
+             |}
+          """.stripMargin
+        ).as[CitizenDetailsResponse] shouldBe citizenDetailsResponse
+      }
+    }
+}


### PR DESCRIPTION
This fixes the citizen details reader to parse both a Long and a Json Date. As citizen-details is in between schemas in different environments it makes sense to use both.