### PR TITLE
NISP-2434: Remove URLS from VNICS page and move to messages

### DIFF
--- a/app/uk/gov/hmrc/nisp/views/nirecordVoluntaryContributions.scala.html
+++ b/app/uk/gov/hmrc/nisp/views/nirecordVoluntaryContributions.scala.html
@@ -68,9 +68,9 @@ sidebarLinks = None) {
     <div class="panel-indent">
         <p>@Messages("nisp.nirecord.voluntarycontributions.h2title.2.help.message")</p>
         <ul class="list-bullet">
-            <li><a href="https://www.moneyadviceservice.org.uk/en" rel="external" target="_blank" data-journey-click="checkmystatepension:external:moneyadvice">@Messages("nisp.nirecord.voluntarycontributions.h2title.2.help.link1")</a></li>
-            <li><a href="https://www.pensionwise.gov.uk/" rel="external" target="_blank" data-journey-click="checkmystatepension:external:pensionwise">@Messages("nisp.nirecord.voluntarycontributions.h2title.2.help.link2")</a>&nbsp;@Html(Messages("nisp.nirecord.voluntarycontributions.h2title.2.help.link2.message"))</li>
-            <li><a href="https://www.citizensadvice.org.uk/" rel="external" target="_blank" data-journey-click="checkmystatepension:external:citizenadvice">@Messages("nisp.nirecord.voluntarycontributions.h2title.2.help.link3")</a></li>
+            <li>@Html(Messages("nisp.nirecord.voluntarycontributions.h2title.2.help.link1"))</li>
+            <li>@Html(Messages("nisp.nirecord.voluntarycontributions.h2title.2.help.link2"))</a>&nbsp;@Html(Messages("nisp.nirecord.voluntarycontributions.h2title.2.help.link2.message"))</li>
+            <li>@Html(Messages("nisp.nirecord.voluntarycontributions.h2title.2.help.link3"))</li>
         </ul>
     </div>
 </details>

--- a/conf/messages
+++ b/conf/messages
@@ -345,10 +345,10 @@ nisp.nirecord.voluntarycontributions.h2title.2 = 2. Seek guidance or financial a
 nisp.nirecord.voluntarycontributions.h2title.2.message = Paying voluntary contributions may not be your best option when planning for your retirement.
 nisp.nirecord.voluntarycontributions.h2title.2.help.title = Where you can get guidance and advice
 nisp.nirecord.voluntarycontributions.h2title.2.help.message = You can seek professional financial advice. For free impartial guidance (not on GOV.UK):
-nisp.nirecord.voluntarycontributions.h2title.2.help.link1 = Money Advice Service (opens in new tab)
-nisp.nirecord.voluntarycontributions.h2title.2.help.link2 = Pension wise (opens in new tab)
+nisp.nirecord.voluntarycontributions.h2title.2.help.link1 = <a href="https://www.moneyadviceservice.org.uk/en" rel="external" target="_blank" data-journey-click="checkmystatepension:external:moneyadvice">Money Advice Service (opens in new tab)</a>
+nisp.nirecord.voluntarycontributions.h2title.2.help.link2 = <a href="https://www.pensionwise.gov.uk/" rel="external" target="_blank" data-journey-click="checkmystatepension:external:pensionwise">Pension wise (opens in new tab)</a>
 nisp.nirecord.voluntarycontributions.h2title.2.help.link2.message =  - advice on pensions for over 50s
-nisp.nirecord.voluntarycontributions.h2title.2.help.link3 = Citizens Advice (opens in new tab)
+nisp.nirecord.voluntarycontributions.h2title.2.help.link3 = <a href="https://www.citizensadvice.org.uk/" rel="external" target="_blank" data-journey-click="checkmystatepension:external:citizenadvice">Citizens Advice (opens in new tab)</a>
 
 nisp.nirecord.voluntarycontributions.h2title.3 = 3. Find out how paying voluntary contributions affects your State Pension
 nisp.nirecord.voluntarycontributions.h2title.3.link1 = Contact the Future Pension Centre (opens in new tab)

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -350,10 +350,10 @@ nisp.nirecord.voluntarycontributions.h2title.2 = 2. Chwiliwch am arweiniad neu g
 nisp.nirecord.voluntarycontributions.h2title.2.message = Efallai nad talu cyfraniadau gwirfoddol fydd eich opsiwn gorau wrth gynllunio am eich ymddeoliad.
 nisp.nirecord.voluntarycontributions.h2title.2.help.title = Ble allwch chi gael arweiniad neu gyngor
 nisp.nirecord.voluntarycontributions.h2title.2.help.message = Gallwch chwilio am gyngor ariannol proffesiynol. Am arweiniad di-duedd am ddim (ddim ar GOV.UK):
-nisp.nirecord.voluntarycontributions.h2title.2.help.link1 = Y Gwasanaeth Cynghori Ariannol (agor mewn tab newydd)
-nisp.nirecord.voluntarycontributions.h2title.2.help.link2 = Pension wise (agor mewn tab newydd)
+nisp.nirecord.voluntarycontributions.h2title.2.help.link1 = <a href="https://www.moneyadviceservice.org.uk/cy" rel="external" target="_blank" data-journey-click="checkmystatepension:external:moneyadvice">Y Gwasanaeth Cynghori Ariannol (agor mewn tab newydd)</a>
+nisp.nirecord.voluntarycontributions.h2title.2.help.link2 = <a href="https://www.pensionwise.gov.uk/" rel="external" target="_blank" data-journey-click="checkmystatepension:external:pensionwise">Pension wise (agor mewn tab newydd)</a>
 nisp.nirecord.voluntarycontributions.h2title.2.help.link2.message =  - cyngor ar bensiynau i&rsquo;r rhai dros 50 oed
-nisp.nirecord.voluntarycontributions.h2title.2.help.link3 = Cyngor ar Bopeth (agor mewn tab newydd)
+nisp.nirecord.voluntarycontributions.h2title.2.help.link3 = <a href="https://www.citizensadvice.org.uk/cymraeg/" rel="external" target="_blank" data-journey-click="checkmystatepension:external:citizenadvice">Cyngor ar Bopeth (agor mewn tab newydd)</a>
 
 nisp.nirecord.voluntarycontributions.h2title.3 = 3. Darganfyddwch sut mae talu cyfraniadau gwirfoddol yn effeithio eich Pensiwn y Wladwriaeth
 nisp.nirecord.voluntarycontributions.h2title.3.link1 = Cysylltwch â Chanolfan Bensiwn y Dyfodol (agor mewn tab newydd)

--- a/test/uk/gov/hmrc/nisp/views/VoluntaryContributionsViewSpec.scala
+++ b/test/uk/gov/hmrc/nisp/views/VoluntaryContributionsViewSpec.scala
@@ -95,16 +95,16 @@ class VoluntaryContributionsViewSpec extends UnitSpec with MockitoSugar with Htm
       assertEqualsMessage(htmlAccountDoc, "article.content__body > details:nth-child(9)>div>p", "nisp.nirecord.voluntarycontributions.h2title.2.help.message")
     }
     "render page with text  'Money Advice Service (opens in new tab)'" in {
-      assertEqualsMessage(htmlAccountDoc, "article.content__body > details:nth-child(9)>div>ul.list-bullet>li:nth-child(1)>a", "nisp.nirecord.voluntarycontributions.h2title.2.help.link1")
+      assertEqualsMessage(htmlAccountDoc, "article.content__body > details:nth-child(9)>div>ul.list-bullet>li:nth-child(1)", "nisp.nirecord.voluntarycontributions.h2title.2.help.link1")
     }
     "render page with text  ' Pension wise (opens in new tab)'" in {
-      assertEqualsMessage(htmlAccountDoc, "article.content__body > details:nth-child(9)>div>ul.list-bullet>li:nth-child(2)>a", "nisp.nirecord.voluntarycontributions.h2title.2.help.link2")
+      assertElemetsOwnMessage(htmlAccountDoc, "article.content__body > details:nth-child(9)>div>ul.list-bullet>li:nth-child(2)", "nisp.nirecord.voluntarycontributions.h2title.2.help.link2.message")
     }
     "render page with link  'Pension wise (opens in new tab)'' " in {
       assertContainsMessageBetweenTags(htmlAccountDoc, "article.content__body >details:nth-child(9)>div>ul.list-bullet>li:nth-child(2)", "nisp.nirecord.voluntarycontributions.h2title.2.help.link2.message","details:nth-child(9)>div>ul.list-bullet>li:nth-child(2)>a")
     }
     "render page with text  'Citizens Advice (opens in new tab)'" in {
-      assertEqualsMessage(htmlAccountDoc, "article.content__body > details:nth-child(9)>div>ul.list-bullet>li:nth-child(3)>a", "nisp.nirecord.voluntarycontributions.h2title.2.help.link3")
+      assertEqualsMessage(htmlAccountDoc, "article.content__body > details:nth-child(9)>div>ul.list-bullet>li:nth-child(3)", "nisp.nirecord.voluntarycontributions.h2title.2.help.link3")
     }
     "render page with text  '3.  Find out how paying voluntary contributions affects your State Pension ' " in {
       assertEqualsMessage(htmlAccountDoc, "article.content__body > h2.heading-medium:nth-child(10)", "nisp.nirecord.voluntarycontributions.h2title.3")


### PR DESCRIPTION
@swaistle and @Shaju-11 - the love @nehadotkannaujia has sorted out the unit tests on this one so should be simple and straightforward

@prashantchoudhari and @dspork - I have moved the URLs from the page to the messages file (as there are some Welsh versions of the pages they are going to)