### PR TITLE
Parse TaxYears as JsArray and JsObject

### DIFF
--- a/app/uk/gov/hmrc/nisp/models/NationalInsuranceRecord.scala
+++ b/app/uk/gov/hmrc/nisp/models/NationalInsuranceRecord.scala
@@ -33,29 +33,19 @@ case class NationalInsuranceRecord(
                                   )
 
 object NationalInsuranceRecord {
-  implicit val reads: Reads[NationalInsuranceRecord] = Reads[NationalInsuranceRecord] { json =>
-    for {
-      qualifyingYears <- (json \ "qualifyingYears").validate[Int]
-      qualifyingYearsPriorTo1975 <- (json \ "qualifyingYearsPriorTo1975").validate[Int]
-      numberOfGaps <- (json \ "numberOfGaps").validate[Int]
-      numberOfGapsPayable <- (json \ "numberOfGapsPayable").validate[Int]
-      dateOfEntry <- (json \ "dateOfEntry").validate[LocalDate]
-      homeResponsibilitiesProtection <- (json \ "homeResponsibilitiesProtection").validate[Boolean]
-      earningsIncludedUpTo <- (json \ "earningsIncludedUpTo").validate[LocalDate]
-      taxYears <- (json \ "_embedded" \ "taxYears").validate[List[NationalInsuranceTaxYear]]
-    } yield {
-      NationalInsuranceRecord(
-        qualifyingYears,
-        qualifyingYearsPriorTo1975,
-        numberOfGaps,
-        numberOfGapsPayable,
-        dateOfEntry,
-        homeResponsibilitiesProtection,
-        earningsIncludedUpTo,
-        taxYears
-      )
-    }
-  }
+  implicit val reads: Reads[NationalInsuranceRecord] = (
+    (JsPath \ "qualifyingYears").read[Int] and
+      (JsPath \ "qualifyingYearsPriorTo1975").read[Int] and
+      (JsPath \ "numberOfGaps").read[Int] and
+      (JsPath \ "numberOfGapsPayable").read[Int] and
+      (JsPath \ "dateOfEntry").read[LocalDate] and
+      (JsPath \ "homeResponsibilitiesProtection").read[Boolean] and
+      (JsPath \ "earningsIncludedUpTo").read[LocalDate] and
+      (JsPath \ "_embedded" \ "taxYears").read[JsValue].map {
+        case obj: JsObject => List(obj.as[NationalInsuranceTaxYear])
+        case other => other.as[List[NationalInsuranceTaxYear]]
+      }
+    ) (NationalInsuranceRecord.apply _)
 
   implicit val writes: Writes[NationalInsuranceRecord] = (
     (JsPath \ "qualifyingYears").write[Int] and

--- a/test/uk/gov/hmrc/nisp/controllers/NispFrontendControllerSpec.scala
+++ b/test/uk/gov/hmrc/nisp/controllers/NispFrontendControllerSpec.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2017 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package uk.gov.hmrc.nisp.controllers
 
 import org.slf4j.{Logger => Slf4JLogger}

--- a/test/uk/gov/hmrc/nisp/models/NationalnsuranceRecordSpec.scala
+++ b/test/uk/gov/hmrc/nisp/models/NationalnsuranceRecordSpec.scala
@@ -1,0 +1,226 @@
+/*
+ * Copyright 2017 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.nisp.models
+
+import org.joda.time.LocalDate
+import play.api.libs.json.Json
+import uk.gov.hmrc.play.test.UnitSpec
+
+
+class NationalnsuranceRecordSpec extends UnitSpec {
+
+  "NationalInsuranceRecord" when {
+    "there is no years" should {
+      "parse the json correctly" in {
+        Json.parse(
+          """
+            |{
+            |  "_links": {
+            |    "self": {
+            |      "href": "/national-insurance-record/ni/QQ123456A"
+            |    }
+            |  },
+            |  "qualifyingYears": 0,
+            |  "qualifyingYearsPriorTo1975": 0,
+            |  "numberOfGaps": 0,
+            |  "numberOfGapsPayable": 0,
+            |  "dateOfEntry": "2015-05-04",
+            |  "homeResponsibilitiesProtection": false,
+            |  "earningsIncludedUpTo": "2016-04-05",
+            |  "_embedded": {
+            |    "taxYears": []
+            |  }
+            |}
+          """.stripMargin).as[NationalInsuranceRecord] shouldBe
+          NationalInsuranceRecord(
+            qualifyingYears = 0,
+            qualifyingYearsPriorTo1975 = 0,
+            numberOfGaps = 0,
+            numberOfGapsPayable = 0,
+            dateOfEntry = new LocalDate(2015, 5, 4),
+            homeResponsibilitiesProtection = false,
+            earningsIncludedUpTo = new LocalDate(2016, 4, 5),
+            List()
+          )
+      }
+    }
+
+    "there is only one year" should {
+      "parse the json correctly" in {
+        Json.parse(
+          """
+            |{
+            |  "_links": {
+            |    "self": {
+            |      "href": "/national-insurance-record/ni/QQ123456A"
+            |    }
+            |  },
+            |  "qualifyingYears": 1,
+            |  "qualifyingYearsPriorTo1975": 0,
+            |  "numberOfGaps": 0,
+            |  "numberOfGapsPayable": 0,
+            |  "dateOfEntry": "2015-05-04",
+            |  "homeResponsibilitiesProtection": false,
+            |  "earningsIncludedUpTo": "2017-04-05",
+            |  "_embedded": {
+            |    "taxYears": {
+            |      "_links": {
+            |        "self": {
+            |          "href": "/national-insurance-record/ni/QQ123456A/taxyear/2016-17"
+            |        }
+            |      },
+            |      "taxYear": "2016-17",
+            |      "qualifying": true,
+            |      "classOneContributions": 0,
+            |      "classTwoCredits": 0,
+            |      "classThreeCredits": 0,
+            |      "otherCredits": 52,
+            |      "classThreePayable": 0,
+            |      "classThreePayableBy": null,
+            |      "classThreePayableByPenalty": null,
+            |      "payable": false,
+            |      "underInvestigation": false
+            |    }
+            |  }
+            |}
+          """.stripMargin).as[NationalInsuranceRecord] shouldBe
+          NationalInsuranceRecord(
+            qualifyingYears = 1,
+            qualifyingYearsPriorTo1975 = 0,
+            numberOfGaps = 0,
+            numberOfGapsPayable = 0,
+            dateOfEntry = new LocalDate(2015, 5, 4),
+            homeResponsibilitiesProtection = false,
+            earningsIncludedUpTo = new LocalDate(2017, 4, 5),
+            List(NationalInsuranceTaxYear(
+              "2016-17",
+              true,
+              0,
+              0,
+              0,
+              52,
+              0,
+              None,
+              None,
+              false,
+              false
+            ))
+          )
+      }
+    }
+
+    "there is multiple years" should {
+      "parse the json correctly" in {
+        Json.parse(
+          """
+            |{
+            |  "_links": {
+            |    "self": {
+            |      "href": "/national-insurance-record/ni/QQ123456A"
+            |    }
+            |  },
+            |  "qualifyingYears": 1,
+            |  "qualifyingYearsPriorTo1975": 0,
+            |  "numberOfGaps": 1,
+            |  "numberOfGapsPayable": 1,
+            |  "dateOfEntry": "2015-05-04",
+            |  "homeResponsibilitiesProtection": false,
+            |  "earningsIncludedUpTo": "2018-04-05",
+            |  "_embedded": {
+            |    "taxYears": [
+            |      {
+            |        "_links": {
+            |          "self": {
+            |            "href": "/national-insurance-record/ni/QQ123456A/taxyear/2017-18"
+            |          }
+            |        },
+            |        "taxYear": "2017-18",
+            |        "qualifying": false,
+            |        "classOneContributions": 0,
+            |        "classTwoCredits": 0,
+            |        "classThreeCredits": 0,
+            |        "otherCredits": 0,
+            |        "classThreePayable": 722.8,
+            |        "classThreePayableBy": "2019-04-05",
+            |        "classThreePayableByPenalty": "2023-04-05",
+            |        "payable": true,
+            |        "underInvestigation": false
+            |      },
+            |      {
+            |        "_links": {
+            |          "self": {
+            |            "href": "/national-insurance-record/ni/QQ123456A/taxyear/2016-17"
+            |          }
+            |        },
+            |        "taxYear": "2016-17",
+            |        "qualifying": true,
+            |        "classOneContributions": 0,
+            |        "classTwoCredits": 0,
+            |        "classThreeCredits": 0,
+            |        "otherCredits": 52,
+            |        "classThreePayable": 0,
+            |        "classThreePayableBy": null,
+            |        "classThreePayableByPenalty": null,
+            |        "payable": false,
+            |        "underInvestigation": false
+            |      }
+            |    ]
+            |  }
+            |}
+          """.stripMargin).as[NationalInsuranceRecord] shouldBe
+          NationalInsuranceRecord(
+            qualifyingYears = 1,
+            qualifyingYearsPriorTo1975 = 0,
+            numberOfGaps = 1,
+            numberOfGapsPayable = 1,
+            dateOfEntry = new LocalDate(2015, 5, 4),
+            homeResponsibilitiesProtection = false,
+            earningsIncludedUpTo = new LocalDate(2018, 4, 5),
+            List(
+              NationalInsuranceTaxYear(
+                "2017-18",
+                false,
+                0,
+                0,
+                0,
+                0,
+                722.8,
+                Some(new LocalDate(2019, 4, 5)),
+                Some(new LocalDate(2023, 4, 5)),
+                true,
+                false
+              ),
+              NationalInsuranceTaxYear(
+                "2016-17",
+                true,
+                0,
+                0,
+                0,
+                52,
+                0,
+                None,
+                None,
+                false,
+                false
+              )
+            )
+          )
+      }
+    }
+  }
+
+}


### PR DESCRIPTION
This is due to the bug https://github.com/hmrc/play-hal/issues/4.
This changes the JSON reads in NationalInsuranceRecord to read the tax years as an array unless it's a JsObject.