### PR TITLE
DDCNLS-899: State Pension age is removed from deferral

### DIFF
--- a/app/uk/gov/hmrc/nisp/views/includes/deferral.scala.html
+++ b/app/uk/gov/hmrc/nisp/views/includes/deferral.scala.html
@@ -14,8 +14,8 @@
  * limitations under the License.
  *@
 
-@(statePensionAge: Int)(implicit messages: Messages)
+@(statePensionDate: String)(implicit messages: Messages)
 
 <h2 class="heading-medium">@Messages("nisp.main.puttingOff")</h2>
-<p>@Html(Messages("nisp.main.puttingOff.line1", statePensionAge))</p>
+<p>@Html(Messages("nisp.main.puttingOff.line1", statePensionDate))</p>
 <a href="https://www.gov.uk/deferring-state-pension" target="_blank" rel="external">@Html(Messages("nisp.main.puttingOff.linkTitle"))</a>

--- a/app/uk/gov/hmrc/nisp/views/statepension.scala.html
+++ b/app/uk/gov/hmrc/nisp/views/statepension.scala.html
@@ -165,7 +165,7 @@ application: Application)
 
     @for(age <- customerAge) {
         @if(age > Constants.deferralCutOffAge) {
-            @includes.deferral(statePension.pensionAge)
+            @includes.deferral(Dates.formatDate(statePension.pensionDate))
         }
     }
 

--- a/app/uk/gov/hmrc/nisp/views/statepension_forecastonly.scala.html
+++ b/app/uk/gov/hmrc/nisp/views/statepension_forecastonly.scala.html
@@ -94,7 +94,7 @@ partialRetriever: CachedStaticHtmlPartialRetriever, messages: Messages, applicat
 
     @for(age <- customerAge) {
         @if(age > Constants.deferralCutOffAge) {
-            @includes.deferral(statePension.pensionAge)
+            @includes.deferral(Dates.formatDate(statePension.pensionDate))
         }
     }
 

--- a/conf/messages
+++ b/conf/messages
@@ -61,7 +61,7 @@ nisp.main.after = After State Pension age, <span class="nowrap">{0}</span>, you 
 nisp.main.basedOn = You can get your State Pension on
 
 nisp.main.puttingOff = Putting off claiming
-nisp.main.puttingOff.line1 = When you are {0}, you can put off claiming your State Pension. Doing this may mean you get extra State Pension when you do come to claim it. The extra amount, along with your State Pension, forms part of your taxable income.
+nisp.main.puttingOff.line1 = You can put off claiming your State Pension from {0}. Doing this may mean you get extra State Pension when you do come to claim it. The extra amount, along with your State Pension, forms part of your taxable income.
 nisp.main.puttingOff.linkTitle = More on putting off claiming (opens in new tab)
 
 nisp.main.showyourrecord = View your National Insurance record

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -61,7 +61,7 @@ nisp.main.after = Ar ôl oedran Pensiwn y Wladwriaeth, <span class="nowrap">{0}<
 nisp.main.basedOn = Gallwch gael eich Pensiwn y Wladwriaeth ar
 
 nisp.main.puttingOff = Oedi gwneud cais
-nisp.main.puttingOff.line1 = Pan fyddwch yn {0}, gallwch oedi gwneud cais am eich Pensiwn y Wladwriaeth. Gallai gwneud hyn olygu y byddech yn cael mwy o Bensiwn y Wladwriaeth pan fyddwch yn dod i wneud cais amdano. Mae&rsquo;r swm ychwanegol, gyda&rsquo;ch Pensiwn y Wladwriaeth, yn ffurfio rhan o&rsquo;ch incwm trethadwy.
+nisp.main.puttingOff.line1 = Gallwch oedi gwneud cais am eich Pensiwn y Wladwriaeth o’r {0}. Gallai gwneud hyn olygu y byddech yn cael mwy o Bensiwn y Wladwriaeth pan fyddwch yn dod i wneud cais amdano. Mae’r swm ychwanegol, gyda’ch Pensiwn y Wladwriaeth, yn ffurfio rhan o’ch incwm trethadwy.
 nisp.main.puttingOff.linkTitle = Mwy am oedi gwneud cais (agor mewn tab newydd)
 
 nisp.main.showyourrecord = Gweld eich cofnod Yswiriant Gwladol

--- a/test/uk/gov/hmrc/nisp/views/StatePensionViewSpec.scala
+++ b/test/uk/gov/hmrc/nisp/views/StatePensionViewSpec.scala
@@ -208,9 +208,8 @@ class StatePensionViewSpec extends PlaySpec with MockitoSugar with HtmlSpec with
             assertEqualsMessage(htmlAccountDoc, "article.content__body>h2:nth-child(14)", "nisp.main.puttingOff")
           }
 
-          "render page with text  'When you are 67, you can put off claiming your State Pension. Doing this may mean you get extra State Pension when you do come to claim it. " +
-            "The extra amount, along with your State Pension, forms part of your taxable income.'" in {
-            assertContainsDynamicMessage(htmlAccountDoc, "article.content__body>p:nth-child(15)", "nisp.main.puttingOff.line1", "67")
+          "render page with text  'You can put off claiming your State Pension from 7 June 2020. Doing this may mean you get extra State Pension when you do come to claim it. The extra amount, along with your State Pension, forms part of your taxable income.'" in {
+            assertContainsDynamicMessage(htmlAccountDoc, "article.content__body>p:nth-child(15)", "nisp.main.puttingOff.line1", "7 June 2020")
           }
 
           "render page with link 'More on putting off claiming (opens in new tab)'" in {
@@ -377,9 +376,8 @@ class StatePensionViewSpec extends PlaySpec with MockitoSugar with HtmlSpec with
             assertEqualsMessage(htmlAccountDoc, "article.content__body>h2:nth-child(14)", "nisp.main.puttingOff")
           }
 
-          "render page with text  'When you are 67, you can put off claiming your State Pension. Doing this may mean you get extra State Pension when you do come to claim it. " +
-            "The extra amount, along with your State Pension, forms part of your taxable income.'" in {
-            assertContainsDynamicMessage(htmlAccountDoc, "article.content__body>p:nth-child(15)", "nisp.main.puttingOff.line1", "67")
+          "render page with text  'You can put off claiming your State Pension from 7 June 2020. Doing this may mean you get extra State Pension when you do come to claim it. The extra amount, along with your State Pension, forms part of your taxable income.'" in {
+            assertContainsDynamicMessage(htmlAccountDoc, "article.content__body>p:nth-child(15)", "nisp.main.puttingOff.line1", "7 June 2020")
           }
 
           "render page with link 'More on putting off claiming (opens in new tab)'" in {
@@ -545,9 +543,8 @@ class StatePensionViewSpec extends PlaySpec with MockitoSugar with HtmlSpec with
             assertEqualsMessage(htmlAccountDoc, "article.content__body>h2:nth-child(14)", "nisp.main.puttingOff")
           }
 
-          "render page with text  'When you are 67, you can put off claiming your State Pension. Doing this may mean you get extra State Pension when you do come to claim it. " +
-            "The extra amount, along with your State Pension, forms part of your taxable income.'" in {
-            assertContainsDynamicMessage(htmlAccountDoc, "article.content__body>p:nth-child(15)", "nisp.main.puttingOff.line1", "67")
+          "render page with text  'You can put off claiming your State Pension from 7 June 2017. Doing this may mean you get extra State Pension when you do come to claim it. The extra amount, along with your State Pension, forms part of your taxable income.'" in {
+            assertContainsDynamicMessage(htmlAccountDoc, "article.content__body>p:nth-child(15)", "nisp.main.puttingOff.line1", "7 June 2017")
           }
 
           "render page with link 'More on putting off claiming (opens in new tab)'" in {
@@ -684,9 +681,8 @@ class StatePensionViewSpec extends PlaySpec with MockitoSugar with HtmlSpec with
             assertEqualsMessage(htmlAccountDoc, "article.content__body>h2:nth-child(12)", "nisp.main.puttingOff")
           }
 
-          "render page with text  'When you are 67, you can put off claiming your State Pension. Doing this may mean you get extra State Pension when you do come to claim it. " +
-            "The extra amount, along with your State Pension, forms part of your taxable income.'" in {
-            assertContainsDynamicMessage(htmlAccountDoc, "article.content__body>p:nth-child(13)", "nisp.main.puttingOff.line1", "67")
+          "render page with text  'You can put off claiming your State Pension from 7 June 2022. Doing this may mean you get extra State Pension when you do come to claim it. The extra amount, along with your State Pension, forms part of your taxable income.'" in {
+            assertContainsDynamicMessage(htmlAccountDoc, "article.content__body>p:nth-child(13)", "nisp.main.puttingOff.line1", "7 June 2022")
           }
 
           "render page with link 'More on putting off claiming (opens in new tab)'" in {
@@ -824,9 +820,8 @@ class StatePensionViewSpec extends PlaySpec with MockitoSugar with HtmlSpec with
             assertEqualsMessage(htmlAccountDoc, "article.content__body>h2:nth-child(13)", "nisp.main.puttingOff")
           }
 
-          "render page with text  'When you are 67, you can put off claiming your State Pension. Doing this may mean you get extra State Pension when you do come to claim it. " +
-            "The extra amount, along with your State Pension, forms part of your taxable income.'" in {
-            assertContainsDynamicMessage(htmlAccountDoc, "article.content__body>p:nth-child(14)", "nisp.main.puttingOff.line1", "67")
+          "render page with text  'You can put off claiming your State Pension from 7 June 2017. Doing this may mean you get extra State Pension when you do come to claim it. The extra amount, along with your State Pension, forms part of your taxable income.'" in {
+            assertContainsDynamicMessage(htmlAccountDoc, "article.content__body>p:nth-child(14)", "nisp.main.puttingOff.line1", "7 June 2017")
           }
 
           "render page with link 'More on putting off claiming (opens in new tab)'" in {
@@ -951,9 +946,8 @@ class StatePensionViewSpec extends PlaySpec with MockitoSugar with HtmlSpec with
           assertEqualsMessage(htmlAccountDoc, "article.content__body>h2:nth-child(10)", "nisp.main.puttingOff")
         }
 
-        "render page with text  'When you are 67, you can put off claiming your State Pension. Doing this may mean you get extra State Pension when you do come to claim it. " +
-          "The extra amount, along with your State Pension, forms part of your taxable income.'" in {
-          assertContainsDynamicMessage(htmlAccountDoc, "article.content__body>p:nth-child(11)", "nisp.main.puttingOff.line1", "67")
+        "render page with text  'You can put off claiming your State Pension from 7 June 2017. Doing this may mean you get extra State Pension when you do come to claim it. The extra amount, along with your State Pension, forms part of your taxable income.'" in {
+          assertContainsDynamicMessage(htmlAccountDoc, "article.content__body>p:nth-child(11)", "nisp.main.puttingOff.line1", "7 June 2017")
         }
 
         "render page with link 'More on putting off claiming (opens in new tab)'" in {

--- a/test/uk/gov/hmrc/nisp/views/StatePension_CopeViewSpec.scala
+++ b/test/uk/gov/hmrc/nisp/views/StatePension_CopeViewSpec.scala
@@ -160,9 +160,8 @@ class StatePension_CopeViewSpec extends PlaySpec with MockitoSugar with HtmlSpec
       assertEqualsMessage(htmlAccountDoc, "article.content__body>h2:nth-child(14)", "nisp.main.puttingOff")
     }
 
-    "render page with text  'When you are 67, you can put off claiming your State Pension. Doing this may mean you get extra State Pension when you do come to claim it. " +
-      "The extra amount, along with your State Pension, forms part of your taxable income.'" in {
-      assertContainsDynamicMessage(htmlAccountDoc, "article.content__body>p:nth-child(15)", "nisp.main.puttingOff.line1", "67")
+    "render page with text  'You can put off claiming your State Pension from 18 July 2021. Doing this may mean you get extra State Pension when you do come to claim it. The extra amount, along with your State Pension, forms part of your taxable income.'" in {
+      assertContainsDynamicMessage(htmlAccountDoc, "article.content__body>p:nth-child(15)", "nisp.main.puttingOff.line1", "18 July 2021")
     }
 
     "render page with link 'More on putting off claiming (opens in new tab)'" in {

--- a/test/uk/gov/hmrc/nisp/views/StatePension_MQPViewSpec.scala
+++ b/test/uk/gov/hmrc/nisp/views/StatePension_MQPViewSpec.scala
@@ -202,9 +202,8 @@ class StatePension_MQPViewSpec extends PlaySpec with MockitoSugar with HtmlSpec 
           assertEqualsMessage(htmlAccountDoc, "article.content__body>h2:nth-child(10)", "nisp.main.puttingOff")
         }
 
-        "render page with text  'When you are 67, you can put off claiming your State Pension. Doing this may mean you get extra State Pension when you do come to claim it. " +
-          "The extra amount, along with your State Pension, forms part of your taxable income.'" in {
-          assertContainsDynamicMessage(htmlAccountDoc, "article.content__body>p:nth-child(11)", "nisp.main.puttingOff.line1", "67")
+        "render page with text  'You can put off claiming your State Pension from 7 June 2020. Doing this may mean you get extra State Pension when you do come to claim it. The extra amount, along with your State Pension, forms part of your taxable income.'" in {
+          assertContainsDynamicMessage(htmlAccountDoc, "article.content__body>p:nth-child(11)", "nisp.main.puttingOff.line1", "7 June 2020")
         }
 
         "render page with link 'More on putting off claiming (opens in new tab)'" in {
@@ -344,9 +343,8 @@ class StatePension_MQPViewSpec extends PlaySpec with MockitoSugar with HtmlSpec 
             assertEqualsMessage(htmlAccountDoc, "article.content__body>h2:nth-child(10)", "nisp.main.puttingOff")
           }
 
-          "render page with text  'When you are 67, you can put off claiming your State Pension. Doing this may mean you get extra State Pension when you do come to claim it. " +
-            "The extra amount, along with your State Pension, forms part of your taxable income.'" in {
-            assertContainsDynamicMessage(htmlAccountDoc, "article.content__body>p:nth-child(11)", "nisp.main.puttingOff.line1", "67")
+          "render page with text  'You can put off claiming your State Pension from 7 June 2020. Doing this may mean you get extra State Pension when you do come to claim it. The extra amount, along with your State Pension, forms part of your taxable income.'" in {
+            assertContainsDynamicMessage(htmlAccountDoc, "article.content__body>p:nth-child(11)", "nisp.main.puttingOff.line1", "7 June 2020")
           }
 
           "render page with link 'More on putting off claiming (opens in new tab)'" in {
@@ -489,9 +487,8 @@ class StatePension_MQPViewSpec extends PlaySpec with MockitoSugar with HtmlSpec 
             assertEqualsMessage(htmlAccountDoc, "article.content__body>h2:nth-child(11)", "nisp.main.puttingOff")
           }
 
-          "render page with text  'When you are 67, you can put off claiming your State Pension. Doing this may mean you get extra State Pension when you do come to claim it. " +
-            "The extra amount, along with your State Pension, forms part of your taxable income.'" in {
-            assertContainsDynamicMessage(htmlAccountDoc, "article.content__body>p:nth-child(12)", "nisp.main.puttingOff.line1", "67")
+          "render page with text  'You can put off claiming your State Pension from 7 June 2020. Doing this may mean you get extra State Pension when you do come to claim it. The extra amount, along with your State Pension, forms part of your taxable income.'" in {
+            assertContainsDynamicMessage(htmlAccountDoc, "article.content__body>p:nth-child(12)", "nisp.main.puttingOff.line1", "7 June 2020")
           }
 
           "render page with link 'More on putting off claiming (opens in new tab)'" in {
@@ -620,9 +617,8 @@ class StatePension_MQPViewSpec extends PlaySpec with MockitoSugar with HtmlSpec 
             assertEqualsMessage(htmlAccountDoc, "article.content__body>h2:nth-child(11)", "nisp.main.puttingOff")
           }
 
-          "render page with text  'When you are 67, you can put off claiming your State Pension. Doing this may mean you get extra State Pension when you do come to claim it. " +
-            "The extra amount, along with your State Pension, forms part of your taxable income.'" in {
-            assertContainsDynamicMessage(htmlAccountDoc, "article.content__body>p:nth-child(12)", "nisp.main.puttingOff.line1", "67")
+          "render page with text  'You can put off claiming your State Pension from 7 June 2020. Doing this may mean you get extra State Pension when you do come to claim it. The extra amount, along with your State Pension, forms part of your taxable income.'" in {
+            assertContainsDynamicMessage(htmlAccountDoc, "article.content__body>p:nth-child(12)", "nisp.main.puttingOff.line1", "7 June 2020")
           }
 
           "render page with link 'More on putting off claiming (opens in new tab)'" in {
@@ -748,9 +744,8 @@ class StatePension_MQPViewSpec extends PlaySpec with MockitoSugar with HtmlSpec 
             assertEqualsMessage(htmlAccountDoc, "article.content__body>h2:nth-child(11)", "nisp.main.puttingOff")
           }
 
-          "render page with text  'When you are 67, you can put off claiming your State Pension. Doing this may mean you get extra State Pension when you do come to claim it. " +
-            "The extra amount, along with your State Pension, forms part of your taxable income.'" in {
-            assertContainsDynamicMessage(htmlAccountDoc, "article.content__body>p:nth-child(12)", "nisp.main.puttingOff.line1", "67")
+          "render page with text  'You can put off claiming your State Pension from 7 June 2020. Doing this may mean you get extra State Pension when you do come to claim it. The extra amount, along with your State Pension, forms part of your taxable income.'" in {
+            assertContainsDynamicMessage(htmlAccountDoc, "article.content__body>p:nth-child(12)", "nisp.main.puttingOff.line1", "7 June 2020")
           }
 
           "render page with link 'More on putting off claiming (opens in new tab)'" in {


### PR DESCRIPTION
DDCNLS-899: State Pension age is removed from deferral message and a new message has been added.
All unit tests passed.

@fred-jackson : Please review the content :-)
@dspork : please review code :-)
@Shaju-11  : Fred is happy with the changes(Check in jira ticket). Its ready to test.