### PR TITLE
 Use untouched Apache License

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2015 HM Revenue and Customs
+   Copyright [yyyy] [name of copyright owner]
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
When using the Apache License, it should not be modified. Individual copyrights notices should be supplied in the source code as stated in the APPENDIX (this has already been done).