### PR TITLE
Add missing space on COPE information page

### DIFF
--- a/app/uk/gov/hmrc/nisp/views/statepension_cope.scala.html
+++ b/app/uk/gov/hmrc/nisp/views/statepension_cope.scala.html
@@ -60,7 +60,7 @@ partialRetriever: CachedStaticHtmlPartialRetriever, messages: Messages, applicat
 </ul>
 <p>@messages("nisp.cope.copeequivalent")</p>
 <h2 class="heading-medium">@messages("nisp.cope.title2")</h2>
-<p>@Html(messages("nisp.cope.table.estimate.title"))<span class="bold-intext">@NispMoney.pounds(copeEstimate) @messages("nisp.main.chart.week")</span>.
+<p>@Html(messages("nisp.cope.table.estimate.title")) <span class="bold-intext">@NispMoney.pounds(copeEstimate) @messages("nisp.main.chart.week")</span>.
 </p>
 <p>@Html(messages("nisp.cope.definition"))</p>
 <p>@Html(messages("nisp.cope.definition.mostcases"))</p>


### PR DESCRIPTION
There's a space missing between the text and monetary amount on the Contracted Out Pension Equivalent (COPE) section of the 'Check your State Pension' service.

It currently displays as `Your COPE estimate is£2.70 a week.`, so I've added in the missing space.

Example:
![COPE](https://user-images.githubusercontent.com/6329861/73615257-20a64a00-45fe-11ea-9bd3-b06c358f0330.png)