### PR TITLE
Html validate CYSP

### DIFF
--- a/app/uk/gov/hmrc/nisp/views/includes/continueWorking.scala.html
+++ b/app/uk/gov/hmrc/nisp/views/includes/continueWorking.scala.html
@@ -25,7 +25,7 @@
 
 @if(statePension.mqpScenario.isDefined)  {
 
-    <h3 class="heading-medium"> @NispMoney.pounds(statePension.amounts.forecast.weeklyAmount) @Html(messages("nisp.main.mostYouCanGet"))</h3>
+    <h2 class="heading-medium"> @NispMoney.pounds(statePension.amounts.forecast.weeklyAmount) @Html(messages("nisp.main.mostYouCanGet"))</h2>
     <p>@messages("nisp.main.context.willReach")</p>
     <p>@Html(messages("nisp.main.context.reachMax.needToPay", LanguageHelper.langUtils.Dates.formatDate(statePension.pensionDate)))</p>
 

--- a/app/uk/gov/hmrc/nisp/views/includes/reached.scala.html
+++ b/app/uk/gov/hmrc/nisp/views/includes/reached.scala.html
@@ -28,7 +28,7 @@
     <li>@Html(messages("nisp.main.inflation"))</li>
     @if(statePension.pensionSharingOrder) {<li>@Html(messages("nisp.main.psod"))</li>}
 </ul>
-<h3 class="heading-medium"> @NispMoney.pounds(statePension.amounts.forecast.weeklyAmount) @Html(messages("nisp.main.mostYouCanGet"))</h3>
+<h2 class="heading-medium"> @NispMoney.pounds(statePension.amounts.forecast.weeklyAmount) @Html(messages("nisp.main.mostYouCanGet"))</h2>
 <p>@messages("nisp.main.cantImprove")</p>
 <p>@Html(messages("nisp.main.context.reachMax.needToPay", (LanguageHelper.langUtils.Dates.formatDate(statePension.pensionDate)).toString()))</p>
 <a href='@routes.NIRecordController.showFull.url'>@messages("nisp.main.showyourrecord")</a>

--- a/app/uk/gov/hmrc/nisp/views/main.scala.html
+++ b/app/uk/gov/hmrc/nisp/views/main.scala.html
@@ -207,7 +207,7 @@
 
 @headerClass = @{
     if (mainTemplateParams.h1Class.isDefined){
-        mainTemplateParams.h1Class.get + "heading-large top-title-heading heading-bottom-margin"
+        mainTemplateParams.h1Class.get
     } else {
         "heading-large top-title-heading heading-bottom-margin"
     }

--- a/app/uk/gov/hmrc/nisp/views/main.scala.html
+++ b/app/uk/gov/hmrc/nisp/views/main.scala.html
@@ -207,8 +207,8 @@
 
 @headerClass = @{
     if (mainTemplateParams.h1Class.isDefined){
-        mainTemplateParams.h1Class.get + " top-title-heading heading-bottom-margin"
-    }else{
+        mainTemplateParams.h1Class.get + "heading-large top-title-heading heading-bottom-margin"
+    } else {
         "heading-large top-title-heading heading-bottom-margin"
     }
 }

--- a/app/uk/gov/hmrc/nisp/views/unauthenticatedMain.scala.html
+++ b/app/uk/gov/hmrc/nisp/views/unauthenticatedMain.scala.html
@@ -198,7 +198,7 @@
 
 @headerClass = @{
     if (mainTemplateParams.h1Class.isDefined){
-        mainTemplateParams.h1Class.get + " top-title-heading heading-bottom-margin"
+        mainTemplateParams.h1Class.get
     }else{
         "heading-large top-title-heading heading-bottom-margin"
     }


### PR DESCRIPTION
Fixes the following HTML Validation errors which occur multiple times: 

Attribute “heading-bottom-margin” not allowed on element “h1” at this point.

Attribute “heading-bottom-margin” not allowed on element “h1” at this point.


