### PR TITLE
removed CSRF bypass because no allowlist header present

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -26,11 +26,6 @@ play.modules.enabled += "uk.gov.hmrc.nisp.config.NispModule"
 
 play.http.requestHandler = "play.api.http.GlobalSettingsHttpRequestHandler"
 
-play.filters.csrf.header.bypassHeaders {
-    X-Requested-With = "*"
-    Csrf-Token = "nocheck"
-}
-
 application.langs = "en,cy"
 
 application.session.httpOnly= true


### PR DESCRIPTION
The CSRF bypass header is being used without an allowlist. Have removed it in this commit to close this vulnerability.
https://jira.tools.tax.service.gov.uk/browse/PSEC-1051